### PR TITLE
fix: contains and like filter Op

### DIFF
--- a/backend/src/processor/data.ts
+++ b/backend/src/processor/data.ts
@@ -689,20 +689,21 @@ class DataProcessor {
   #addFilterQuery(query: PostgrestFilterBuilder<any, any, any>, filter: FilterType) {
     const filterValue = filter?.filterValue?.trim();
     switch (filter?.filterOp) {
+      case 'contains':
+      case 'like':
+        query.ilike(filter.filterKey, `%${filterValue}%`);
+        break;
       case 'equals':
         query.eq(filter.filterKey, filterValue);
-        break;
-      case 'notEqual':
-        query.neq(filter.filterKey, filterValue);
-        break;
-      case 'like':
-        query.like(filter.filterKey, filterValue);
         break;
       case 'greaterThan':
         query.gt(filter.filterKey, filterValue);
         break;
       case 'lessThan':
         query.lt(filter.filterKey, filterValue);
+        break;
+      case 'notEqual':
+        query.neq(filter.filterKey, filterValue);
         break;
       default:
         break;

--- a/backend/src/types/filter.ts
+++ b/backend/src/types/filter.ts
@@ -1,5 +1,5 @@
 export interface FilterType {
-  filterOp: 'equals' | 'notEqual' | 'like' | 'greaterThan' | 'lessThan';
   filterKey: string;
+  filterOp: 'contains' | 'equals' | 'greaterThan' | 'lessThan' | 'like' | 'notEqual';
   filterValue: string;
 }


### PR DESCRIPTION
- add missing `contains` operator
- same handling for `contains` and `like`

@ahennr 
