### PR TITLE
feat: show env variables when form backend starts

### DIFF
--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -20,26 +20,26 @@ const prepare = async () => {
   logger.debug('Preparing app');
 
   const opts: Opts = {
-    FORM_CONFIGS_DIR: process.env.FORM_CONFIGS_DIR ?? 'form_configs',
     FILE_UPLOAD_DIR: process.env.FILE_UPLOAD_DIR ?? 'files',
-    SIZE_LIMIT: process.env.SIZE_LIMIT ?? '100kb',
-    POSTGREST_URL: process.env.POSTGREST_URL ?? 'http://postgrest:3000',
+    FORM_CONFIGS_DIR: process.env.FORM_CONFIGS_DIR ?? 'form_configs',
+    KC_AUTH_SERVER_URL: process.env.KC_AUTH_SERVER_URL,
+    KC_CLIENT_APP_ID: process.env.KC_CLIENT_APP_ID,
+    KC_PUBLIC_KEY: harmonizePublicKey(process.env.KC_PUBLIC_KEY),
+    KC_REALM: process.env.KC_REALM,
     POSTGREST_DEFAULT_SCHEMA: process.env.POSTGREST_DEFAULT_SCHEMA ?? 'public',
     POSTGREST_JWT_CLIENT_ID: process.env.POSTGREST_JWT_CLIENT_ID,
     POSTGREST_KEYCLOAK_CLIENT_SECRET: process.env.POSTGREST_KEYCLOAK_CLIENT_SECRET,
-    KC_REALM: process.env.KC_REALM,
-    KC_AUTH_SERVER_URL: process.env.KC_AUTH_SERVER_URL,
-    KC_PUBLIC_KEY: harmonizePublicKey(process.env.KC_PUBLIC_KEY),
-    KC_CLIENT_APP_ID: process.env.KC_CLIENT_APP_ID
+    POSTGREST_URL: process.env.POSTGREST_URL ?? 'http://postgrest:3000',
+    SIZE_LIMIT: process.env.SIZE_LIMIT ?? '100kb'
   } as Opts;
 
   const requiredKeys: (keyof Opts)[] = [
-    'POSTGREST_JWT_CLIENT_ID',
-    'POSTGREST_KEYCLOAK_CLIENT_SECRET',
-    'KC_REALM',
     'KC_AUTH_SERVER_URL',
+    'KC_CLIENT_APP_ID',
     'KC_PUBLIC_KEY',
-    'KC_CLIENT_APP_ID'
+    'KC_REALM',
+    'POSTGREST_JWT_CLIENT_ID',
+    'POSTGREST_KEYCLOAK_CLIENT_SECRET'
   ];
 
   const allKeysPresent = requiredKeys.every(key => opts[key] !== undefined);
@@ -69,7 +69,13 @@ const run = (opts: Opts) => {
   app.use('/', apiRouter);
 
   app.listen(port, () => {
-    logger.info(`form-backend listening at localhost:${port}`);
+    logger.info('----------------------------------------');
+    logger.info(`🚀 form-backend listening at localhost:${port}`);
+    logger.info('📦 Environment variables loaded:');
+    Object.keys(opts).forEach((key) => {
+      logger.debug(`🌐 ${key}: ${opts[key as keyof Opts]}`);
+    });
+    logger.info('----------------------------------------');
   });
 };
 


### PR DESCRIPTION
## Description

<!-- Please give a short description of the changes you propose. Please use prose and try not to be too technical, if possible. Make sure to mention people that you think should know about the PR. -->

In order to improve debugging, loaded opts / environment variables are shown when the backend has started.

## Related issues or pull requests

<!-- Please list issues or pull requests that the changes you propose are related to. It does not matter if they are still open and/or unmerged, any link is appreciated. -->

## Pull request type

<!-- Please check the type of change your PR introduces: -->

<!-- Put an x between the square brackets to check an item, like so: [x] -->

- [ ] Bugfix
- [x] Feature
- [ ] Dependency updates
- [ ] Tests
- [x] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe)

## Do you introduce a breaking change?

- [ ] Yes
- [x] No

## Checklist

- [x] I understand and agree that the changes in this PR will be licensed under the 
  [BSD 2-Clause Licence](https://github.com/formcapture/form-backend/blob/main/LICENSE).
- [x] I have followed the [guidelines for contributing](https://github.com/formcapture/form-backend/blob/main/CONTRIBUTING.md).
- [x] The proposed change fits to the content of the [code of conduct](https://github.com/formcapture/form-backend/blob/main/CODE_OF_CONDUCT.md).
- [ ] I have added or updated tests and documentation, and the test suite passes (run `npm test` in `/backend` and/or `/app` locally).
- [ ] I have added a screenshot/screencast to illustrate the visual output of my update.
