### PR TITLE
Fix: Set Headers directly in PostgresClient constructor call

### DIFF
--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -109,6 +109,9 @@ if (JSONEditor && JSONEditor.defaults && JSONEditor.defaults.editors && JSONEdit
   });
 }
 
+// @ts-expect-error This should be injected by vite
+const checkLoginIframe = import.meta.env.MODE !== 'development';
+
 const App: React.FC = () => {
   const view = new URLSearchParams(window.location.search).get('view');
   const formId = new URLSearchParams(window.location.search).get('formId');
@@ -146,7 +149,8 @@ const App: React.FC = () => {
       // Will force a reload afterwards so
       // we do not have to put this into state.
       await newKc.init({
-        onLoad: 'login-required'
+        onLoad: 'login-required',
+        checkLoginIframe
       });
     } catch (err) {
       Logger.error('Failed to initialize keycloak', err);
@@ -178,7 +182,7 @@ const App: React.FC = () => {
         throw new Error('Failed to fetch data');
       }
       const json = await response.json();
-      if (json.data === undefined) {
+      if (json.config === undefined) {
         throw new Error('Failed to fetch data');
       }
       return json;
@@ -209,7 +213,8 @@ const App: React.FC = () => {
 
     try {
       await kc.init({
-        onLoad: 'check-sso'
+        onLoad: 'check-sso',
+        checkLoginIframe
       });
     } catch (err) {
       Logger.error('Failed to initialize keycloak', err);

--- a/app/src/Component/TableView/TableView.tsx
+++ b/app/src/Component/TableView/TableView.tsx
@@ -191,6 +191,7 @@ const TableView: React.FC<TableViewProps> = ({
     );
   };
 
+
   const renderGeometryTooltip = useCallback(() => 'Geometrie', []);
 
   const zoomToFeature = useCallback((rowProps: any) => {
@@ -511,7 +512,7 @@ const TableView: React.FC<TableViewProps> = ({
   }, [data, filter, formId, order, page]);
 
   useEffect(() => {
-    if (!containsGeometryColumns) {
+    if (!containsGeometryColumns || !data || !data.config) {
       return;
     }
     const showFeaturesInMap = () => {

--- a/backend/src/processor/data.ts
+++ b/backend/src/processor/data.ts
@@ -135,7 +135,7 @@ class DataProcessor {
     sanitizedData = this.#fileProcessor.getItemWithoutFiles(sanitizedData, Object.keys(keysAndFiles));
 
     const response = await this.#pgClient
-      .schema(formConfig.dataSource.schema || this.#pgClient.schemaName!)
+      .schema(formConfig.dataSource.schema || this.#pgClient.schemaName)
       .from(tableName)
       .insert(sanitizedData)
       .select();

--- a/backend/src/processor/form.spec.ts
+++ b/backend/src/processor/form.spec.ts
@@ -58,11 +58,15 @@ describe('FormProcessor', () => {
       }
     };
 
-    await FormProcessor.createFormProcessor(opts, formConfig, 'foo', userRoles, '');
+    const myToken = 'test-token';
+
+    await FormProcessor.createFormProcessor(opts, formConfig, 'foo', userRoles, myToken);
 
     expect(PostgrestClient).toHaveBeenCalledTimes(1);
     expect(PostgrestClient).toHaveBeenCalledWith(opts.POSTGREST_URL, {
-      fetch: expect.any(Function),
+      headers: {
+        Authorization: `Bearer ${myToken}`
+      },
       schema: opts.POSTGREST_DEFAULT_SCHEMA
     });
   });

--- a/backend/src/processor/form.ts
+++ b/backend/src/processor/form.ts
@@ -35,11 +35,8 @@ export class FormProcessor {
   ) {
     const pgClient = new PostgrestClient(opts.POSTGREST_URL, {
       schema: opts.POSTGREST_DEFAULT_SCHEMA,
-      fetch: (resource, options) => {
-        options = options ?? {};
-        options.headers = options.headers as {} ?? {};
-        options.headers.Authorization = `Bearer ${postgrestToken}`;
-        return fetch(resource, options);
+      headers: {
+        Authorization: `Bearer ${postgrestToken}`
       }
     });
 

--- a/backend/src/service/form.ts
+++ b/backend/src/service/form.ts
@@ -197,6 +197,7 @@ class FormService {
         userRoles,
         postgrestToken
       );
+
       const createResponse = await formProcessor.createFormItem(req.body);
 
       return res.json(createResponse);


### PR DESCRIPTION
## Description

<!-- Please give a short description of the changes you propose. Please use prose and try not to be too technical, if possible. Make sure to mention people that you think should know about the PR. -->

This PR fixes issues with update, create, and delete operations.

As of version 1.16.0, supabase/postgrest-js supports setting headers on a per-call basis, removing the need to override fetch. See the [release notes](https://github.com/supabase/postgrest-js/releases/tag/v1.16.0) for more details. In the currently used version, the inconsistent use of a custom fetch implementation appears to cause errors during CRUD operations.

Plz review @hblitza @jansule 

## Related issues or pull requests

<!-- Please list issues or pull requests that the changes you propose are related to. It does not matter if they are still open and/or unmerged, any link is appreciated. -->

## Pull request type

<!-- Please check the type of change your PR introduces: -->

<!-- Put an x between the square brackets to check an item, like so: [x] -->

- [x] Bugfix
- [ ] Feature
- [ ] Dependency updates
- [ ] Tests
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe)

## Do you introduce a breaking change?

- [ ] Yes
- [x] No

## Checklist

- [x] I understand and agree that the changes in this PR will be licensed under the 
  [BSD 2-Clause Licence](https://github.com/formcapture/form-backend/blob/main/LICENSE).
- [x] I have followed the [guidelines for contributing](https://github.com/formcapture/form-backend/blob/main/CONTRIBUTING.md).
- [x] The proposed change fits to the content of the [code of conduct](https://github.com/formcapture/form-backend/blob/main/CODE_OF_CONDUCT.md).
- [x] I have added or updated tests and documentation, and the test suite passes (run `npm test` in `/backend` and/or `/app` locally).
- [ ] I have added a screenshot/screencast to illustrate the visual output of my update.
