### PR TITLE
Feature(backend): Check connection to database via postgrest client on startup

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.0-semantically-released",
       "license": "BSD-2-Clause",
       "dependencies": {
-        "@supabase/postgrest-js": "^1.21.1",
+        "@supabase/postgrest-js": "^1.21.3",
         "dotenv": "^17.2.1",
         "express": "^4.21.2",
         "helmet": "^8.0.0",
@@ -27,8 +27,8 @@
         "@types/lodash.merge": "^4.6.9",
         "@types/mime-types": "^3.0.1",
         "@types/node": "^24.2.0",
-        "@typescript-eslint/eslint-plugin": "^8.34.0",
-        "@typescript-eslint/parser": "^8.38.0",
+        "@typescript-eslint/eslint-plugin": "^8.41.0",
+        "@typescript-eslint/parser": "^8.41.0",
         "eslint": "^9.34.0",
         "eslint-plugin-import": "^2.31.0",
         "jest": "^30.0.5",
@@ -39,7 +39,7 @@
         "typedoc": "^0.28.9",
         "typedoc-plugin-missing-exports": "^4.0.0",
         "typescript": "^5.9.2",
-        "typescript-eslint": "^8.39.0"
+        "typescript-eslint": "^8.41.0"
       },
       "engines": {
         "node": ">=20",
@@ -86,22 +86,22 @@
       }
     },
     "node_modules/@babel/core": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.28.0.tgz",
-      "integrity": "sha512-UlLAnTPrFdNGoFtbSXwcGFQBtQZJCNjaN6hQNP3UPvuNXT1i82N26KL3dZeIpNalWywr9IuQuncaAfUaS1g6sQ==",
+      "version": "7.28.3",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.28.3.tgz",
+      "integrity": "sha512-yDBHV9kQNcr2/sUr9jghVyz9C3Y5G2zUM2H2lo+9mKv4sFgbA8s8Z9t8D1jiTkGoO/NoIfKMyKWr4s6CN23ZwQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.27.1",
-        "@babel/generator": "^7.28.0",
+        "@babel/generator": "^7.28.3",
         "@babel/helper-compilation-targets": "^7.27.2",
-        "@babel/helper-module-transforms": "^7.27.3",
-        "@babel/helpers": "^7.27.6",
-        "@babel/parser": "^7.28.0",
+        "@babel/helper-module-transforms": "^7.28.3",
+        "@babel/helpers": "^7.28.3",
+        "@babel/parser": "^7.28.3",
         "@babel/template": "^7.27.2",
-        "@babel/traverse": "^7.28.0",
-        "@babel/types": "^7.28.0",
+        "@babel/traverse": "^7.28.3",
+        "@babel/types": "^7.28.2",
         "convert-source-map": "^2.0.0",
         "debug": "^4.1.0",
         "gensync": "^1.0.0-beta.2",
@@ -127,14 +127,14 @@
       }
     },
     "node_modules/@babel/generator": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.28.0.tgz",
-      "integrity": "sha512-lJjzvrbEeWrhB4P3QBsH7tey117PjLZnDbLiQEKjQ/fNJTjuq4HSqgFA+UNSwZT8D7dxxbnuSBMsa1lrWzKlQg==",
+      "version": "7.28.3",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.28.3.tgz",
+      "integrity": "sha512-3lSpxGgvnmZznmBkCRnVREPUFJv2wrv9iAoFDvADJc0ypmdOxdUtcLeBgBJ6zE0PMeTKnxeQzyk0xTBq4Ep7zw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/parser": "^7.28.0",
-        "@babel/types": "^7.28.0",
+        "@babel/parser": "^7.28.3",
+        "@babel/types": "^7.28.2",
         "@jridgewell/gen-mapping": "^0.3.12",
         "@jridgewell/trace-mapping": "^0.3.28",
         "jsesc": "^3.0.2"
@@ -195,15 +195,15 @@
       }
     },
     "node_modules/@babel/helper-module-transforms": {
-      "version": "7.27.3",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.27.3.tgz",
-      "integrity": "sha512-dSOvYwvyLsWBeIRyOeHXp5vPj5l1I011r52FM1+r1jCERv+aFXYk4whgQccYEGYxK2H3ZAIA8nuPkQ0HaUo3qg==",
+      "version": "7.28.3",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.28.3.tgz",
+      "integrity": "sha512-gytXUbs8k2sXS9PnQptz5o0QnpLL51SwASIORY6XaBKF88nsOT0Zw9szLqlSGQDP/4TljBAD5y98p2U1fqkdsw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-module-imports": "^7.27.1",
         "@babel/helper-validator-identifier": "^7.27.1",
-        "@babel/traverse": "^7.27.3"
+        "@babel/traverse": "^7.28.3"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -253,27 +253,27 @@
       }
     },
     "node_modules/@babel/helpers": {
-      "version": "7.27.6",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.27.6.tgz",
-      "integrity": "sha512-muE8Tt8M22638HU31A3CgfSUciwz1fhATfoVai05aPXGor//CdWDCbnlY1yvBPo07njuVOCNGCSp/GTt12lIug==",
+      "version": "7.28.3",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.28.3.tgz",
+      "integrity": "sha512-PTNtvUQihsAsDHMOP5pfobP8C6CM4JWXmP8DrEIt46c3r2bf87Ua1zoqevsMo9g+tWDwgWrFP5EIxuBx5RudAw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/template": "^7.27.2",
-        "@babel/types": "^7.27.6"
+        "@babel/types": "^7.28.2"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.28.0.tgz",
-      "integrity": "sha512-jVZGvOxOuNSsuQuLRTh13nU0AogFlw32w/MT+LV6D3sP5WdbW61E77RnkbaO2dUvmPAYrBDJXGn5gGS6tH4j8g==",
+      "version": "7.28.3",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.28.3.tgz",
+      "integrity": "sha512-7+Ey1mAgYqFAx2h0RuoxcQT5+MlG3GTV0TQrgr7/ZliKsm/MNDxVVutlWaziMq7wJNAz8MTqz55XLpWvva6StA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.28.0"
+        "@babel/types": "^7.28.2"
       },
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -537,18 +537,18 @@
       }
     },
     "node_modules/@babel/traverse": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.28.0.tgz",
-      "integrity": "sha512-mGe7UK5wWyh0bKRfupsUchrQGqvDbZDbKJw+kcRGSmdHVYrv+ltd0pnpDTVpiTqnaBru9iEvA8pz8W46v0Amwg==",
+      "version": "7.28.3",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.28.3.tgz",
+      "integrity": "sha512-7w4kZYHneL3A6NP2nxzHvT3HCZ7puDZZjFMqDpBPECub79sTtSO5CGXDkKrTQq8ksAwfD/XI2MRFX23njdDaIQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
-        "@babel/generator": "^7.28.0",
+        "@babel/generator": "^7.28.3",
         "@babel/helper-globals": "^7.28.0",
-        "@babel/parser": "^7.28.0",
+        "@babel/parser": "^7.28.3",
         "@babel/template": "^7.27.2",
-        "@babel/types": "^7.28.0",
+        "@babel/types": "^7.28.2",
         "debug": "^4.3.1"
       },
       "engines": {
@@ -556,9 +556,9 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.28.1",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.28.1.tgz",
-      "integrity": "sha512-x0LvFTekgSX+83TI28Y9wYPUfzrnl2aT5+5QLnO6v7mSJYtEEevuDRN0F0uSHRk1G1IWZC43o00Y0xDDrpBGPQ==",
+      "version": "7.28.2",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.28.2.tgz",
+      "integrity": "sha512-ruv7Ae4J5dUYULmeXw1gmb7rYRz57OWCPM57pHojnLq/3Z1CK2lNSLTCVjxVk1F/TZHwOZZrOWi0ur95BbLxNQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -869,16 +869,16 @@
       }
     },
     "node_modules/@gerrit0/mini-shiki": {
-      "version": "3.9.1",
-      "resolved": "https://registry.npmjs.org/@gerrit0/mini-shiki/-/mini-shiki-3.9.1.tgz",
-      "integrity": "sha512-quvtbDhNf528BkMHQQd8xGJMpmA5taDZuex/JDF8ETEjS2iypXzr1hnEUVh+lTUyffFJ0JCxysUsiuUoEGIz/Q==",
+      "version": "3.11.0",
+      "resolved": "https://registry.npmjs.org/@gerrit0/mini-shiki/-/mini-shiki-3.11.0.tgz",
+      "integrity": "sha512-ooCDMAOKv71O7MszbXjSQGcI6K5T6NKlemQZOBHLq7Sv/oXCRfYbZ7UgbzFdl20lSXju6Juds4I3y30R6rHA4Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@shikijs/engine-oniguruma": "^3.9.1",
-        "@shikijs/langs": "^3.9.1",
-        "@shikijs/themes": "^3.9.1",
-        "@shikijs/types": "^3.9.1",
+        "@shikijs/engine-oniguruma": "^3.11.0",
+        "@shikijs/langs": "^3.11.0",
+        "@shikijs/themes": "^3.11.0",
+        "@shikijs/types": "^3.11.0",
         "@shikijs/vscode-textmate": "^10.0.2"
       }
     },
@@ -1107,16 +1107,16 @@
       }
     },
     "node_modules/@jest/console": {
-      "version": "30.0.5",
-      "resolved": "https://registry.npmjs.org/@jest/console/-/console-30.0.5.tgz",
-      "integrity": "sha512-xY6b0XiL0Nav3ReresUarwl2oIz1gTnxGbGpho9/rbUWsLH0f1OD/VT84xs8c7VmH7MChnLb0pag6PhZhAdDiA==",
+      "version": "30.1.0",
+      "resolved": "https://registry.npmjs.org/@jest/console/-/console-30.1.0.tgz",
+      "integrity": "sha512-qCEJKC53Z/mpRcxuK8wg0rnkUKoAeN+pet1T7Da/l8WPGzSWdE+RIUQM+LN5bQkNH5PBUab+ua9BiFTW0hKXSQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jest/types": "30.0.5",
         "@types/node": "*",
         "chalk": "^4.1.2",
-        "jest-message-util": "30.0.5",
+        "jest-message-util": "30.1.0",
         "jest-util": "30.0.5",
         "slash": "^3.0.0"
       },
@@ -1125,17 +1125,17 @@
       }
     },
     "node_modules/@jest/core": {
-      "version": "30.0.5",
-      "resolved": "https://registry.npmjs.org/@jest/core/-/core-30.0.5.tgz",
-      "integrity": "sha512-fKD0OulvRsXF1hmaFgHhVJzczWzA1RXMMo9LTPuFXo9q/alDbME3JIyWYqovWsUBWSoBcsHaGPSLF9rz4l9Qeg==",
+      "version": "30.1.0",
+      "resolved": "https://registry.npmjs.org/@jest/core/-/core-30.1.0.tgz",
+      "integrity": "sha512-pxSGVBndJFgHS8IuW6gT39kmbZwPvBZfnqJG4lN9xS++0hxuINsitpTswq8hiaZo+R/OYjVbuw0ee+UDsrK4aw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@jest/console": "30.0.5",
+        "@jest/console": "30.1.0",
         "@jest/pattern": "30.0.1",
-        "@jest/reporters": "30.0.5",
-        "@jest/test-result": "30.0.5",
-        "@jest/transform": "30.0.5",
+        "@jest/reporters": "30.1.0",
+        "@jest/test-result": "30.1.0",
+        "@jest/transform": "30.1.0",
         "@jest/types": "30.0.5",
         "@types/node": "*",
         "ansi-escapes": "^4.3.2",
@@ -1144,18 +1144,18 @@
         "exit-x": "^0.2.2",
         "graceful-fs": "^4.2.11",
         "jest-changed-files": "30.0.5",
-        "jest-config": "30.0.5",
-        "jest-haste-map": "30.0.5",
-        "jest-message-util": "30.0.5",
+        "jest-config": "30.1.0",
+        "jest-haste-map": "30.1.0",
+        "jest-message-util": "30.1.0",
         "jest-regex-util": "30.0.1",
-        "jest-resolve": "30.0.5",
-        "jest-resolve-dependencies": "30.0.5",
-        "jest-runner": "30.0.5",
-        "jest-runtime": "30.0.5",
-        "jest-snapshot": "30.0.5",
+        "jest-resolve": "30.1.0",
+        "jest-resolve-dependencies": "30.1.0",
+        "jest-runner": "30.1.0",
+        "jest-runtime": "30.1.0",
+        "jest-snapshot": "30.1.0",
         "jest-util": "30.0.5",
-        "jest-validate": "30.0.5",
-        "jest-watcher": "30.0.5",
+        "jest-validate": "30.1.0",
+        "jest-watcher": "30.1.0",
         "micromatch": "^4.0.8",
         "pretty-format": "30.0.5",
         "slash": "^3.0.0"
@@ -1183,13 +1183,13 @@
       }
     },
     "node_modules/@jest/environment": {
-      "version": "30.0.5",
-      "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-30.0.5.tgz",
-      "integrity": "sha512-aRX7WoaWx1oaOkDQvCWImVQ8XNtdv5sEWgk4gxR6NXb7WBUnL5sRak4WRzIQRZ1VTWPvV4VI4mgGjNL9TeKMYA==",
+      "version": "30.1.0",
+      "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-30.1.0.tgz",
+      "integrity": "sha512-a9yjDya5j/6jFFCbuF3wBlxHzaFNRpZBpO52VP80BzgEfLFY7ZlZnS8K3qZGlKYiA02tLCJL3R6+66l1lY05zQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@jest/fake-timers": "30.0.5",
+        "@jest/fake-timers": "30.1.0",
         "@jest/types": "30.0.5",
         "@types/node": "*",
         "jest-mock": "30.0.5"
@@ -1199,43 +1199,43 @@
       }
     },
     "node_modules/@jest/expect": {
-      "version": "30.0.5",
-      "resolved": "https://registry.npmjs.org/@jest/expect/-/expect-30.0.5.tgz",
-      "integrity": "sha512-6udac8KKrtTtC+AXZ2iUN/R7dp7Ydry+Fo6FPFnDG54wjVMnb6vW/XNlf7Xj8UDjAE3aAVAsR4KFyKk3TCXmTA==",
+      "version": "30.1.0",
+      "resolved": "https://registry.npmjs.org/@jest/expect/-/expect-30.1.0.tgz",
+      "integrity": "sha512-Mnl7ZZ0NurliixNfFGTJ1aC+RBi2p9fFj+0RCsrXJDouaYZbQ7IZbmI9OWsf8f3BsBS/0UWCBztyXmHTn0Q8dQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "expect": "30.0.5",
-        "jest-snapshot": "30.0.5"
+        "expect": "30.1.0",
+        "jest-snapshot": "30.1.0"
       },
       "engines": {
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
     "node_modules/@jest/expect-utils": {
-      "version": "30.0.5",
-      "resolved": "https://registry.npmjs.org/@jest/expect-utils/-/expect-utils-30.0.5.tgz",
-      "integrity": "sha512-F3lmTT7CXWYywoVUGTCmom0vXq3HTTkaZyTAzIy+bXSBizB7o5qzlC9VCtq0arOa8GqmNsbg/cE9C6HLn7Szew==",
+      "version": "30.1.0",
+      "resolved": "https://registry.npmjs.org/@jest/expect-utils/-/expect-utils-30.1.0.tgz",
+      "integrity": "sha512-3anLWpBieOCIvDYkEoHTK3351znRkmtAiOyURPRwn3IIT2TLlwqkgl6P7wk5mxwW04MZvHHx/gw1qGb3VPDmLA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@jest/get-type": "30.0.1"
+        "@jest/get-type": "30.1.0"
       },
       "engines": {
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
     "node_modules/@jest/fake-timers": {
-      "version": "30.0.5",
-      "resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-30.0.5.tgz",
-      "integrity": "sha512-ZO5DHfNV+kgEAeP3gK3XlpJLL4U3Sz6ebl/n68Uwt64qFFs5bv4bfEEjyRGK5uM0C90ewooNgFuKMdkbEoMEXw==",
+      "version": "30.1.0",
+      "resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-30.1.0.tgz",
+      "integrity": "sha512-Yei5/jGS0OZbPaLOUMrWVjAlwrlQWPkrBx2lp9M1kx79q2O4JJnrXRCEGgag06zN+a4M3FKatw7g1GYcNATPMg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jest/types": "30.0.5",
         "@sinonjs/fake-timers": "^13.0.0",
         "@types/node": "*",
-        "jest-message-util": "30.0.5",
+        "jest-message-util": "30.1.0",
         "jest-mock": "30.0.5",
         "jest-util": "30.0.5"
       },
@@ -1244,9 +1244,9 @@
       }
     },
     "node_modules/@jest/get-type": {
-      "version": "30.0.1",
-      "resolved": "https://registry.npmjs.org/@jest/get-type/-/get-type-30.0.1.tgz",
-      "integrity": "sha512-AyYdemXCptSRFirI5EPazNxyPwAL0jXt3zceFjaj8NFiKP9pOi0bfXonf6qkf82z2t3QWPeLCWWw4stPBzctLw==",
+      "version": "30.1.0",
+      "resolved": "https://registry.npmjs.org/@jest/get-type/-/get-type-30.1.0.tgz",
+      "integrity": "sha512-eMbZE2hUnx1WV0pmURZY9XoXPkUYjpc55mb0CrhtdWLtzMQPFvu/rZkTLZFTsdaVQa+Tr4eWAteqcUzoawq/uA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1254,14 +1254,14 @@
       }
     },
     "node_modules/@jest/globals": {
-      "version": "30.0.5",
-      "resolved": "https://registry.npmjs.org/@jest/globals/-/globals-30.0.5.tgz",
-      "integrity": "sha512-7oEJT19WW4oe6HR7oLRvHxwlJk2gev0U9px3ufs8sX9PoD1Eza68KF0/tlN7X0dq/WVsBScXQGgCldA1V9Y/jA==",
+      "version": "30.1.0",
+      "resolved": "https://registry.npmjs.org/@jest/globals/-/globals-30.1.0.tgz",
+      "integrity": "sha512-zZEscSJnh/yNA+7Rw0aNtIy6DZ9EQGWK2PD7Ig934Y/5xJOOGnLBgGKG4YNkORhkR4UZo33CKwaazSy1+Rfosw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@jest/environment": "30.0.5",
-        "@jest/expect": "30.0.5",
+        "@jest/environment": "30.1.0",
+        "@jest/expect": "30.1.0",
         "@jest/types": "30.0.5",
         "jest-mock": "30.0.5"
       },
@@ -1284,16 +1284,16 @@
       }
     },
     "node_modules/@jest/reporters": {
-      "version": "30.0.5",
-      "resolved": "https://registry.npmjs.org/@jest/reporters/-/reporters-30.0.5.tgz",
-      "integrity": "sha512-mafft7VBX4jzED1FwGC1o/9QUM2xebzavImZMeqnsklgcyxBto8mV4HzNSzUrryJ+8R9MFOM3HgYuDradWR+4g==",
+      "version": "30.1.0",
+      "resolved": "https://registry.npmjs.org/@jest/reporters/-/reporters-30.1.0.tgz",
+      "integrity": "sha512-BJg8JUaJrX9Q01DUFs4+/P9XMsYivfoafXr/vjxy43rRebkd8ZC+NrxEh2tBdOBS5ow89dSL2mIcAFqASQCU3w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@bcoe/v8-coverage": "^0.2.3",
-        "@jest/console": "30.0.5",
-        "@jest/test-result": "30.0.5",
-        "@jest/transform": "30.0.5",
+        "@jest/console": "30.1.0",
+        "@jest/test-result": "30.1.0",
+        "@jest/transform": "30.1.0",
         "@jest/types": "30.0.5",
         "@jridgewell/trace-mapping": "^0.3.25",
         "@types/node": "*",
@@ -1307,9 +1307,9 @@
         "istanbul-lib-report": "^3.0.0",
         "istanbul-lib-source-maps": "^5.0.0",
         "istanbul-reports": "^3.1.3",
-        "jest-message-util": "30.0.5",
+        "jest-message-util": "30.1.0",
         "jest-util": "30.0.5",
-        "jest-worker": "30.0.5",
+        "jest-worker": "30.1.0",
         "slash": "^3.0.0",
         "string-length": "^4.0.2",
         "v8-to-istanbul": "^9.0.1"
@@ -1340,9 +1340,9 @@
       }
     },
     "node_modules/@jest/snapshot-utils": {
-      "version": "30.0.5",
-      "resolved": "https://registry.npmjs.org/@jest/snapshot-utils/-/snapshot-utils-30.0.5.tgz",
-      "integrity": "sha512-XcCQ5qWHLvi29UUrowgDFvV4t7ETxX91CbDczMnoqXPOIcZOxyNdSjm6kV5XMc8+HkxfRegU/MUmnTbJRzGrUQ==",
+      "version": "30.1.0",
+      "resolved": "https://registry.npmjs.org/@jest/snapshot-utils/-/snapshot-utils-30.1.0.tgz",
+      "integrity": "sha512-8Hc0WVaquUqVQ9J3inaJtV3EvkLzep81qtuS0l/gD7huGPEZCf6TZWugvaF6LpZARw6oLF291E5Y3e+eKcZe1w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1371,13 +1371,13 @@
       }
     },
     "node_modules/@jest/test-result": {
-      "version": "30.0.5",
-      "resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-30.0.5.tgz",
-      "integrity": "sha512-wPyztnK0gbDMQAJZ43tdMro+qblDHH1Ru/ylzUo21TBKqt88ZqnKKK2m30LKmLLoKtR2lxdpCC/P3g1vfKcawQ==",
+      "version": "30.1.0",
+      "resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-30.1.0.tgz",
+      "integrity": "sha512-ByBm3rucBDAeYUsArrOq6dnYIRsQ0dogs0DqOWaYjPvO4McVQYb/6dVNz9vIqz3hJbhb7b/XF5ZBLoTxUNJwbQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@jest/console": "30.0.5",
+        "@jest/console": "30.1.0",
         "@jest/types": "30.0.5",
         "@types/istanbul-lib-coverage": "^2.0.6",
         "collect-v8-coverage": "^1.0.2"
@@ -1387,15 +1387,15 @@
       }
     },
     "node_modules/@jest/test-sequencer": {
-      "version": "30.0.5",
-      "resolved": "https://registry.npmjs.org/@jest/test-sequencer/-/test-sequencer-30.0.5.tgz",
-      "integrity": "sha512-Aea/G1egWoIIozmDD7PBXUOxkekXl7ueGzrsGGi1SbeKgQqCYCIf+wfbflEbf2LiPxL8j2JZGLyrzZagjvW4YQ==",
+      "version": "30.1.0",
+      "resolved": "https://registry.npmjs.org/@jest/test-sequencer/-/test-sequencer-30.1.0.tgz",
+      "integrity": "sha512-qKfPCHMEHP+vLdGOVkoxbR42deneEdlAtJkn5z/h0HSfd8LJyUbTysO5esd1hJu9pXmeK6yA9ug1ccV+OJKFPg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@jest/test-result": "30.0.5",
+        "@jest/test-result": "30.1.0",
         "graceful-fs": "^4.2.11",
-        "jest-haste-map": "30.0.5",
+        "jest-haste-map": "30.1.0",
         "slash": "^3.0.0"
       },
       "engines": {
@@ -1403,9 +1403,9 @@
       }
     },
     "node_modules/@jest/transform": {
-      "version": "30.0.5",
-      "resolved": "https://registry.npmjs.org/@jest/transform/-/transform-30.0.5.tgz",
-      "integrity": "sha512-Vk8amLQCmuZyy6GbBht1Jfo9RSdBtg7Lks+B0PecnjI8J+PCLQPGh7uI8Q/2wwpW2gLdiAfiHNsmekKlywULqg==",
+      "version": "30.1.0",
+      "resolved": "https://registry.npmjs.org/@jest/transform/-/transform-30.1.0.tgz",
+      "integrity": "sha512-OvzganIbExZDS2jl37re14XSJXK3sREyGP641RL+Ek1galupCMLWHlxop+4wQnVX7e3fxF6C3W16VzWdl2ducQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1417,7 +1417,7 @@
         "convert-source-map": "^2.0.0",
         "fast-json-stable-stringify": "^2.1.0",
         "graceful-fs": "^4.2.11",
-        "jest-haste-map": "30.0.5",
+        "jest-haste-map": "30.1.0",
         "jest-regex-util": "30.0.1",
         "jest-util": "30.0.5",
         "micromatch": "^4.0.8",
@@ -1449,9 +1449,9 @@
       }
     },
     "node_modules/@jridgewell/gen-mapping": {
-      "version": "0.3.12",
-      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.12.tgz",
-      "integrity": "sha512-OuLGC46TjB5BbN1dH8JULVVZY4WTdkF7tV9Ys6wLL1rubZnCMstOhNHueU5bLCrnRuDhKPDM4g6sw4Bel5Gzqg==",
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1470,16 +1470,16 @@
       }
     },
     "node_modules/@jridgewell/sourcemap-codec": {
-      "version": "1.5.4",
-      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.4.tgz",
-      "integrity": "sha512-VT2+G1VQs/9oz078bLrYbecdZKs912zQlkelYpuf+SXF+QvZDYJlbx/LSx+meSAwdDFnF8FVXW92AVjjkVmgFw==",
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@jridgewell/trace-mapping": {
-      "version": "0.3.29",
-      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.29.tgz",
-      "integrity": "sha512-uw6guiW/gcAGPDhLmd77/6lW8QLeiV5RUTsAX46Db6oLhGaVj4lhnPwb184s1bkc8kdVg/+h988dro8GRDpmYQ==",
+      "version": "0.3.30",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.30.tgz",
+      "integrity": "sha512-GQ7Nw5G2lTu/BtHTKfXhKHok2WGetd4XYcVKGx00SjAk8GMwgJM3zr6zORiPGuOE+/vkc90KtTosSSvaCjKb2Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1570,40 +1570,40 @@
       "license": "MIT"
     },
     "node_modules/@shikijs/engine-oniguruma": {
-      "version": "3.9.1",
-      "resolved": "https://registry.npmjs.org/@shikijs/engine-oniguruma/-/engine-oniguruma-3.9.1.tgz",
-      "integrity": "sha512-WPlL/xqviwS3te4unSGGGfflKsuHLMI6tPdNYvgz/IygcBT6UiwDFSzjBKyebwi5GGSlXsjjdoJLIBnAplmEZw==",
+      "version": "3.12.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/engine-oniguruma/-/engine-oniguruma-3.12.0.tgz",
+      "integrity": "sha512-IfDl3oXPbJ/Jr2K8mLeQVpnF+FxjAc7ZPDkgr38uEw/Bg3u638neSrpwqOTnTHXt1aU0Fk1/J+/RBdst1kVqLg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@shikijs/types": "3.9.1",
+        "@shikijs/types": "3.12.0",
         "@shikijs/vscode-textmate": "^10.0.2"
       }
     },
     "node_modules/@shikijs/langs": {
-      "version": "3.9.1",
-      "resolved": "https://registry.npmjs.org/@shikijs/langs/-/langs-3.9.1.tgz",
-      "integrity": "sha512-Vyy2Yv9PP3Veh3VSsIvNncOR+O93wFsNYgN2B6cCCJlS7H9SKFYc55edsqernsg8WT/zam1cfB6llJsQWLnVhA==",
+      "version": "3.12.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/langs/-/langs-3.12.0.tgz",
+      "integrity": "sha512-HIca0daEySJ8zuy9bdrtcBPhcYBo8wR1dyHk1vKrOuwDsITtZuQeGhEkcEfWc6IDyTcom7LRFCH6P7ljGSCEiQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@shikijs/types": "3.9.1"
+        "@shikijs/types": "3.12.0"
       }
     },
     "node_modules/@shikijs/themes": {
-      "version": "3.9.1",
-      "resolved": "https://registry.npmjs.org/@shikijs/themes/-/themes-3.9.1.tgz",
-      "integrity": "sha512-zAykkGECNICCMXpKeVvq04yqwaSuAIvrf8MjsU5bzskfg4XreU+O0B5wdNCYRixoB9snd3YlZ373WV5E/g5T9A==",
+      "version": "3.12.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/themes/-/themes-3.12.0.tgz",
+      "integrity": "sha512-/lxvQxSI5s4qZLV/AuFaA4Wt61t/0Oka/P9Lmpr1UV+HydNCczO3DMHOC/CsXCCpbv4Zq8sMD0cDa7mvaVoj0Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@shikijs/types": "3.9.1"
+        "@shikijs/types": "3.12.0"
       }
     },
     "node_modules/@shikijs/types": {
-      "version": "3.9.1",
-      "resolved": "https://registry.npmjs.org/@shikijs/types/-/types-3.9.1.tgz",
-      "integrity": "sha512-rqM3T7a0iM1oPKz9iaH/cVgNX9Vz1HERcUcXJ94/fulgVdwqfnhXzGxO4bLrAnh/o5CPLy3IcYedogfV+Ns0Qg==",
+      "version": "3.12.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/types/-/types-3.12.0.tgz",
+      "integrity": "sha512-jsFzm8hCeTINC3OCmTZdhR9DOl/foJWplH2Px0bTi4m8z59fnsueLsweX82oGcjRQ7mfQAluQYKGoH2VzsWY4A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1619,9 +1619,9 @@
       "license": "MIT"
     },
     "node_modules/@sinclair/typebox": {
-      "version": "0.34.38",
-      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.34.38.tgz",
-      "integrity": "sha512-HpkxMmc2XmZKhvaKIZZThlHmx1L0I/V1hWK1NubtlFnr6ZqdiOpV72TKudZUNQjZNsyDBay72qFEhEvb+bcwcA==",
+      "version": "0.34.40",
+      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.34.40.tgz",
+      "integrity": "sha512-gwBNIP8ZAYev/ORDWW0QvxdwPXwxBtLsdsJgSc7eDIRt8ubP+rxUBzPsrwnu16fgEF8Bx4lh/+mvQvJzcTM6Kw==",
       "dev": true,
       "license": "MIT"
     },
@@ -1646,15 +1646,15 @@
       }
     },
     "node_modules/@stylistic/eslint-plugin": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/@stylistic/eslint-plugin/-/eslint-plugin-5.2.0.tgz",
-      "integrity": "sha512-RCEdbREv9EBiToUBQTlRhVYKG093I6ZnnQ990j08eJ6uRZh71DXkOnoxtTLfDQ6utVCVQzrhZFHZP0zfrfOIjA==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@stylistic/eslint-plugin/-/eslint-plugin-5.2.3.tgz",
+      "integrity": "sha512-oY7GVkJGVMI5benlBDCaRrSC1qPasafyv5dOBLLv5MTilMGnErKhO6ziEfodDDIZbo5QxPUNW360VudJOFODMw==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.7.0",
-        "@typescript-eslint/types": "^8.37.0",
+        "@typescript-eslint/types": "^8.38.0",
         "eslint-visitor-keys": "^4.2.1",
         "espree": "^10.4.0",
         "estraverse": "^5.3.0",
@@ -1680,9 +1680,9 @@
       }
     },
     "node_modules/@supabase/postgrest-js": {
-      "version": "1.21.1",
-      "resolved": "https://registry.npmjs.org/@supabase/postgrest-js/-/postgrest-js-1.21.1.tgz",
-      "integrity": "sha512-vy6LRvf4Yt5rub+cToevCYe6x4wVKzWS9mT5dRWfb0Ykx4K5GBUbg43LjdnXuI8/9x/TEzzY+pYoEv1+t0+ZEg==",
+      "version": "1.21.3",
+      "resolved": "https://registry.npmjs.org/@supabase/postgrest-js/-/postgrest-js-1.21.3.tgz",
+      "integrity": "sha512-rg3DmmZQKEVCreXq6Am29hMVe1CzemXyIWVYyyua69y6XubfP+DzGfLxME/1uvdgwqdoaPbtjBDpEBhqxq1ZwA==",
       "license": "MIT",
       "dependencies": {
         "@supabase/node-fetch": "^2.6.14"
@@ -1781,13 +1781,13 @@
       }
     },
     "node_modules/@types/babel__traverse": {
-      "version": "7.20.7",
-      "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.20.7.tgz",
-      "integrity": "sha512-dkO5fhS7+/oos4ciWxyEyjWe48zmG6wbCheo/G2ZnHx4fs3EU6YC6UM8rk56gAjNJ9P3MTH2jo5jb92/K6wbng==",
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.28.0.tgz",
+      "integrity": "sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.20.7"
+        "@babel/types": "^7.28.2"
       }
     },
     "node_modules/@types/body-parser": {
@@ -1963,9 +1963,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "24.2.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.2.0.tgz",
-      "integrity": "sha512-3xyG3pMCq3oYCNg7/ZP+E1ooTaGB4cG8JWRsqqOYQdbWNY4zbaV0Ennrd7stjiJEFZCaybcIgpTjJWHRfBSIDw==",
+      "version": "24.3.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.3.0.tgz",
+      "integrity": "sha512-aPTXCrfwnDLj4VvXrm+UUCQjNEvJgNA8s5F1cvwQU+3KNltTOkBm1j30uNLyqqPNe7gE3KFzImYoZEfLhp4Yow==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2047,17 +2047,17 @@
       "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "8.39.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.39.0.tgz",
-      "integrity": "sha512-bhEz6OZeUR+O/6yx9Jk6ohX6H9JSFTaiY0v9/PuKT3oGK0rn0jNplLmyFUGV+a9gfYnVNwGDwS/UkLIuXNb2Rw==",
+      "version": "8.41.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.41.0.tgz",
+      "integrity": "sha512-8fz6oa6wEKZrhXWro/S3n2eRJqlRcIa6SlDh59FXJ5Wp5XRZ8B9ixpJDcjadHq47hMx0u+HW6SNa6LjJQ6NLtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/regexpp": "^4.10.0",
-        "@typescript-eslint/scope-manager": "8.39.0",
-        "@typescript-eslint/type-utils": "8.39.0",
-        "@typescript-eslint/utils": "8.39.0",
-        "@typescript-eslint/visitor-keys": "8.39.0",
+        "@typescript-eslint/scope-manager": "8.41.0",
+        "@typescript-eslint/type-utils": "8.41.0",
+        "@typescript-eslint/utils": "8.41.0",
+        "@typescript-eslint/visitor-keys": "8.41.0",
         "graphemer": "^1.4.0",
         "ignore": "^7.0.0",
         "natural-compare": "^1.4.0",
@@ -2071,22 +2071,22 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "@typescript-eslint/parser": "^8.39.0",
+        "@typescript-eslint/parser": "^8.41.0",
         "eslint": "^8.57.0 || ^9.0.0",
         "typescript": ">=4.8.4 <6.0.0"
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "8.39.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.39.0.tgz",
-      "integrity": "sha512-g3WpVQHngx0aLXn6kfIYCZxM6rRJlWzEkVpqEFLT3SgEDsp9cpCbxxgwnE504q4H+ruSDh/VGS6nqZIDynP+vg==",
+      "version": "8.41.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.41.0.tgz",
+      "integrity": "sha512-gTtSdWX9xiMPA/7MV9STjJOOYtWwIJIYxkQxnSV1U3xcE+mnJSH3f6zI0RYP+ew66WSlZ5ed+h0VCxsvdC1jJg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/scope-manager": "8.39.0",
-        "@typescript-eslint/types": "8.39.0",
-        "@typescript-eslint/typescript-estree": "8.39.0",
-        "@typescript-eslint/visitor-keys": "8.39.0",
+        "@typescript-eslint/scope-manager": "8.41.0",
+        "@typescript-eslint/types": "8.41.0",
+        "@typescript-eslint/typescript-estree": "8.41.0",
+        "@typescript-eslint/visitor-keys": "8.41.0",
         "debug": "^4.3.4"
       },
       "engines": {
@@ -2102,14 +2102,14 @@
       }
     },
     "node_modules/@typescript-eslint/project-service": {
-      "version": "8.39.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.39.0.tgz",
-      "integrity": "sha512-CTzJqaSq30V/Z2Og9jogzZt8lJRR5TKlAdXmWgdu4hgcC9Kww5flQ+xFvMxIBWVNdxJO7OifgdOK4PokMIWPew==",
+      "version": "8.41.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.41.0.tgz",
+      "integrity": "sha512-b8V9SdGBQzQdjJ/IO3eDifGpDBJfvrNTp2QD9P2BeqWTGrRibgfgIlBSw6z3b6R7dPzg752tOs4u/7yCLxksSQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/tsconfig-utils": "^8.39.0",
-        "@typescript-eslint/types": "^8.39.0",
+        "@typescript-eslint/tsconfig-utils": "^8.41.0",
+        "@typescript-eslint/types": "^8.41.0",
         "debug": "^4.3.4"
       },
       "engines": {
@@ -2124,14 +2124,14 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "8.39.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.39.0.tgz",
-      "integrity": "sha512-8QOzff9UKxOh6npZQ/4FQu4mjdOCGSdO3p44ww0hk8Vu+IGbg0tB/H1LcTARRDzGCC8pDGbh2rissBuuoPgH8A==",
+      "version": "8.41.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.41.0.tgz",
+      "integrity": "sha512-n6m05bXn/Cd6DZDGyrpXrELCPVaTnLdPToyhBoFkLIMznRUQUEQdSp96s/pcWSQdqOhrgR1mzJ+yItK7T+WPMQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.39.0",
-        "@typescript-eslint/visitor-keys": "8.39.0"
+        "@typescript-eslint/types": "8.41.0",
+        "@typescript-eslint/visitor-keys": "8.41.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -2142,9 +2142,9 @@
       }
     },
     "node_modules/@typescript-eslint/tsconfig-utils": {
-      "version": "8.39.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.39.0.tgz",
-      "integrity": "sha512-Fd3/QjmFV2sKmvv3Mrj8r6N8CryYiCS8Wdb/6/rgOXAWGcFuc+VkQuG28uk/4kVNVZBQuuDHEDUpo/pQ32zsIQ==",
+      "version": "8.41.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.41.0.tgz",
+      "integrity": "sha512-TDhxYFPUYRFxFhuU5hTIJk+auzM/wKvWgoNYOPcOf6i4ReYlOoYN8q1dV5kOTjNQNJgzWN3TUUQMtlLOcUgdUw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2159,15 +2159,15 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "8.39.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.39.0.tgz",
-      "integrity": "sha512-6B3z0c1DXVT2vYA9+z9axjtc09rqKUPRmijD5m9iv8iQpHBRYRMBcgxSiKTZKm6FwWw1/cI4v6em35OsKCiN5Q==",
+      "version": "8.41.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.41.0.tgz",
+      "integrity": "sha512-63qt1h91vg3KsjVVonFJWjgSK7pZHSQFKH6uwqxAH9bBrsyRhO6ONoKyXxyVBzG1lJnFAJcKAcxLS54N1ee1OQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.39.0",
-        "@typescript-eslint/typescript-estree": "8.39.0",
-        "@typescript-eslint/utils": "8.39.0",
+        "@typescript-eslint/types": "8.41.0",
+        "@typescript-eslint/typescript-estree": "8.41.0",
+        "@typescript-eslint/utils": "8.41.0",
         "debug": "^4.3.4",
         "ts-api-utils": "^2.1.0"
       },
@@ -2184,9 +2184,9 @@
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "8.39.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.39.0.tgz",
-      "integrity": "sha512-ArDdaOllnCj3yn/lzKn9s0pBQYmmyme/v1HbGIGB0GB/knFI3fWMHloC+oYTJW46tVbYnGKTMDK4ah1sC2v0Kg==",
+      "version": "8.41.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.41.0.tgz",
+      "integrity": "sha512-9EwxsWdVqh42afLbHP90n2VdHaWU/oWgbH2P0CfcNfdKL7CuKpwMQGjwev56vWu9cSKU7FWSu6r9zck6CVfnag==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2198,16 +2198,16 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "8.39.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.39.0.tgz",
-      "integrity": "sha512-ndWdiflRMvfIgQRpckQQLiB5qAKQ7w++V4LlCHwp62eym1HLB/kw7D9f2e8ytONls/jt89TEasgvb+VwnRprsw==",
+      "version": "8.41.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.41.0.tgz",
+      "integrity": "sha512-D43UwUYJmGhuwHfY7MtNKRZMmfd8+p/eNSfFe6tH5mbVDto+VQCayeAt35rOx3Cs6wxD16DQtIKw/YXxt5E0UQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/project-service": "8.39.0",
-        "@typescript-eslint/tsconfig-utils": "8.39.0",
-        "@typescript-eslint/types": "8.39.0",
-        "@typescript-eslint/visitor-keys": "8.39.0",
+        "@typescript-eslint/project-service": "8.41.0",
+        "@typescript-eslint/tsconfig-utils": "8.41.0",
+        "@typescript-eslint/types": "8.41.0",
+        "@typescript-eslint/visitor-keys": "8.41.0",
         "debug": "^4.3.4",
         "fast-glob": "^3.3.2",
         "is-glob": "^4.0.3",
@@ -2227,16 +2227,16 @@
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "8.39.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.39.0.tgz",
-      "integrity": "sha512-4GVSvNA0Vx1Ktwvf4sFE+exxJ3QGUorQG1/A5mRfRNZtkBT2xrA/BCO2H0eALx/PnvCS6/vmYwRdDA41EoffkQ==",
+      "version": "8.41.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.41.0.tgz",
+      "integrity": "sha512-udbCVstxZ5jiPIXrdH+BZWnPatjlYwJuJkDA4Tbo3WyYLh8NvB+h/bKeSZHDOFKfphsZYJQqaFtLeXEqurQn1A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.7.0",
-        "@typescript-eslint/scope-manager": "8.39.0",
-        "@typescript-eslint/types": "8.39.0",
-        "@typescript-eslint/typescript-estree": "8.39.0"
+        "@typescript-eslint/scope-manager": "8.41.0",
+        "@typescript-eslint/types": "8.41.0",
+        "@typescript-eslint/typescript-estree": "8.41.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -2251,13 +2251,13 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "8.39.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.39.0.tgz",
-      "integrity": "sha512-ldgiJ+VAhQCfIjeOgu8Kj5nSxds0ktPOSO9p4+0VDH2R2pLvQraaM5Oen2d7NxzMCm+Sn/vJT+mv2H5u6b/3fA==",
+      "version": "8.41.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.41.0.tgz",
+      "integrity": "sha512-+GeGMebMCy0elMNg67LRNoVnUFPIm37iu5CmHESVx56/9Jsfdpsvbv605DQ81Pi/x11IdKUsS5nzgTYbCQU9fg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.39.0",
+        "@typescript-eslint/types": "8.41.0",
         "eslint-visitor-keys": "^4.2.1"
       },
       "engines": {
@@ -2648,9 +2648,9 @@
       }
     },
     "node_modules/ansi-regex": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.1.0.tgz",
-      "integrity": "sha512-7HSX4QQb4CspciLpVFwyRe79O3xsIZDDLER21kERQ71oaPodF8jL725AgJMFAYbooIqolJoRLuM81SpeUkpkvA==",
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.0.tgz",
+      "integrity": "sha512-TKY5pyBkHyADOPYlRT9Lx6F544mPl0vS5Ew7BJ45hA08Q+t3GjbueLliBWN3sMICk6+y7HdyxSzC4bWS8baBdg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2878,13 +2878,13 @@
       }
     },
     "node_modules/babel-jest": {
-      "version": "30.0.5",
-      "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-30.0.5.tgz",
-      "integrity": "sha512-mRijnKimhGDMsizTvBTWotwNpzrkHr+VvZUQBof2AufXKB8NXrL1W69TG20EvOz7aevx6FTJIaBuBkYxS8zolg==",
+      "version": "30.1.0",
+      "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-30.1.0.tgz",
+      "integrity": "sha512-xoF2zwb3po3dOJMahde//mE284gcxp9WH8TTbo3Y102fas7Ga1mjGUwrw137RmvUkuA2liISRlg2BFQhmTfeHg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@jest/transform": "30.0.5",
+        "@jest/transform": "30.1.0",
         "@types/babel__core": "^7.20.5",
         "babel-plugin-istanbul": "^7.0.0",
         "babel-preset-jest": "30.0.1",
@@ -2932,9 +2932,9 @@
       }
     },
     "node_modules/babel-preset-current-node-syntax": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/babel-preset-current-node-syntax/-/babel-preset-current-node-syntax-1.1.0.tgz",
-      "integrity": "sha512-ldYss8SbBlWva1bs28q78Ju5Zq1F+8BrqBZZ0VFhLBvhh6lCpC2o3gDJi/5DRLs9FgYZCnmPYIVFU4lRXCkyUw==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/babel-preset-current-node-syntax/-/babel-preset-current-node-syntax-1.2.0.tgz",
+      "integrity": "sha512-E/VlAEzRrsLEb2+dv8yp3bo4scof3l9nR4lrld+Iy5NyVqgVYUJnDAmunkhPMisRI32Qc4iRiz425d8vM++2fg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2955,7 +2955,7 @@
         "@babel/plugin-syntax-top-level-await": "^7.14.5"
       },
       "peerDependencies": {
-        "@babel/core": "^7.0.0"
+        "@babel/core": "^7.0.0 || ^8.0.0-0"
       }
     },
     "node_modules/babel-preset-jest": {
@@ -3058,9 +3058,9 @@
       }
     },
     "node_modules/browserslist": {
-      "version": "4.25.1",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.25.1.tgz",
-      "integrity": "sha512-KGj0KoOMXLpSNkkEI6Z6mShmQy0bc1I+T7K9N81k4WWMrfz+6fQ6es80B/YLAeRoKvjYE1YSHHOW1qe9xIVzHw==",
+      "version": "4.25.3",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.25.3.tgz",
+      "integrity": "sha512-cDGv1kkDI4/0e5yON9yM5G/0A5u8sf5TnmdX5C9qHzI9PPu++sQ9zjm1k9NiOrf3riY4OkK0zSGqfvJyJsgCBQ==",
       "dev": true,
       "funding": [
         {
@@ -3078,8 +3078,8 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "caniuse-lite": "^1.0.30001726",
-        "electron-to-chromium": "^1.5.173",
+        "caniuse-lite": "^1.0.30001735",
+        "electron-to-chromium": "^1.5.204",
         "node-releases": "^2.0.19",
         "update-browserslist-db": "^1.1.3"
       },
@@ -3204,9 +3204,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001727",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001727.tgz",
-      "integrity": "sha512-pB68nIHmbN6L/4C6MH1DokyR3bYqFwjaSs/sWDHGj4CTcFtQUQMuJftVwWkXq7mNWOybD3KhUv3oWHoGxgP14Q==",
+      "version": "1.0.30001737",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001737.tgz",
+      "integrity": "sha512-BiloLiXtQNrY5UyF0+1nSJLXUENuhka2pzy2Fx5pGxqavdrxSCW4U6Pn/PoG3Efspi2frRbHpBV2XsrPE6EDlw==",
       "dev": true,
       "funding": [
         {
@@ -3785,9 +3785,9 @@
       "license": "MIT"
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.185",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.185.tgz",
-      "integrity": "sha512-dYOZfUk57hSMPePoIQ1fZWl1Fkj+OshhEVuPacNKWzC1efe56OsHY3l/jCfiAgIICOU3VgOIdoq7ahg7r7n6MQ==",
+      "version": "1.5.209",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.209.tgz",
+      "integrity": "sha512-Xoz0uMrim9ZETCQt8UgM5FxQF9+imA7PBpokoGcZloA1uw2LeHzTlip5cb5KOAsXZLjh/moN2vReN3ZjJmjI9A==",
       "dev": true,
       "license": "ISC"
     },
@@ -4406,16 +4406,16 @@
       }
     },
     "node_modules/expect": {
-      "version": "30.0.5",
-      "resolved": "https://registry.npmjs.org/expect/-/expect-30.0.5.tgz",
-      "integrity": "sha512-P0te2pt+hHI5qLJkIR+iMvS+lYUZml8rKKsohVHAGY+uClp9XVbdyYNJOIjSRpHVp8s8YqxJCiHUkSYZGr8rtQ==",
+      "version": "30.1.0",
+      "resolved": "https://registry.npmjs.org/expect/-/expect-30.1.0.tgz",
+      "integrity": "sha512-BjTOhEHlQVAXJqkgmxRt33ZbA8H+NLKpZ+Ff0qsFEOhPMNNcdJ160TocOSyiQS8ZNEUHXozg2ykBDboySPTSKQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@jest/expect-utils": "30.0.5",
-        "@jest/get-type": "30.0.1",
-        "jest-matcher-utils": "30.0.5",
-        "jest-message-util": "30.0.5",
+        "@jest/expect-utils": "30.1.0",
+        "@jest/get-type": "30.1.0",
+        "jest-matcher-utils": "30.1.0",
+        "jest-message-util": "30.1.0",
         "jest-mock": "30.0.5",
         "jest-util": "30.0.5"
       },
@@ -5754,9 +5754,9 @@
       }
     },
     "node_modules/istanbul-reports": {
-      "version": "3.1.7",
-      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.1.7.tgz",
-      "integrity": "sha512-BewmUXImeuRk2YY0PVbxgKAysvhRPUQE0h5QRM++nVWyubKGV0l8qQ5op8+B2DOmwSe63Jivj0BjkPQVf8fP5g==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
+      "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -5784,16 +5784,16 @@
       }
     },
     "node_modules/jest": {
-      "version": "30.0.5",
-      "resolved": "https://registry.npmjs.org/jest/-/jest-30.0.5.tgz",
-      "integrity": "sha512-y2mfcJywuTUkvLm2Lp1/pFX8kTgMO5yyQGq/Sk/n2mN7XWYp4JsCZ/QXW34M8YScgk8bPZlREH04f6blPnoHnQ==",
+      "version": "30.1.0",
+      "resolved": "https://registry.npmjs.org/jest/-/jest-30.1.0.tgz",
+      "integrity": "sha512-4/QcV9Yw4+O3Hsjj/71s4fz2WHdJuXd11bbEJYeK7kxF/bZ1Kx1aCjBaXQ5eTeSLSLv3/XwhAhFQaX/KnTF/yw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@jest/core": "30.0.5",
+        "@jest/core": "30.1.0",
         "@jest/types": "30.0.5",
         "import-local": "^3.2.0",
-        "jest-cli": "30.0.5"
+        "jest-cli": "30.1.0"
       },
       "bin": {
         "jest": "bin/jest.js"
@@ -5826,26 +5826,26 @@
       }
     },
     "node_modules/jest-circus": {
-      "version": "30.0.5",
-      "resolved": "https://registry.npmjs.org/jest-circus/-/jest-circus-30.0.5.tgz",
-      "integrity": "sha512-h/sjXEs4GS+NFFfqBDYT7y5Msfxh04EwWLhQi0F8kuWpe+J/7tICSlswU8qvBqumR3kFgHbfu7vU6qruWWBPug==",
+      "version": "30.1.0",
+      "resolved": "https://registry.npmjs.org/jest-circus/-/jest-circus-30.1.0.tgz",
+      "integrity": "sha512-+59Jn7UmRwWiC9GV2mKdf6ei2SGE2/QwO3fn+G7gm3XprNCJsbn+8VFdkI7vKsyRH8yzzPXMnF88XCBcYy8+PQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@jest/environment": "30.0.5",
-        "@jest/expect": "30.0.5",
-        "@jest/test-result": "30.0.5",
+        "@jest/environment": "30.1.0",
+        "@jest/expect": "30.1.0",
+        "@jest/test-result": "30.1.0",
         "@jest/types": "30.0.5",
         "@types/node": "*",
         "chalk": "^4.1.2",
         "co": "^4.6.0",
         "dedent": "^1.6.0",
         "is-generator-fn": "^2.1.0",
-        "jest-each": "30.0.5",
-        "jest-matcher-utils": "30.0.5",
-        "jest-message-util": "30.0.5",
-        "jest-runtime": "30.0.5",
-        "jest-snapshot": "30.0.5",
+        "jest-each": "30.1.0",
+        "jest-matcher-utils": "30.1.0",
+        "jest-message-util": "30.1.0",
+        "jest-runtime": "30.1.0",
+        "jest-snapshot": "30.1.0",
         "jest-util": "30.0.5",
         "p-limit": "^3.1.0",
         "pretty-format": "30.0.5",
@@ -5858,21 +5858,21 @@
       }
     },
     "node_modules/jest-cli": {
-      "version": "30.0.5",
-      "resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-30.0.5.tgz",
-      "integrity": "sha512-Sa45PGMkBZzF94HMrlX4kUyPOwUpdZasaliKN3mifvDmkhLYqLLg8HQTzn6gq7vJGahFYMQjXgyJWfYImKZzOw==",
+      "version": "30.1.0",
+      "resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-30.1.0.tgz",
+      "integrity": "sha512-H18qsWNR73XNzHbafx+UrP8L4EcziiG41S192You2tfellKSj5BERpAovjh+RMHtuCId4F50VC/JuwPVNaFkRg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@jest/core": "30.0.5",
-        "@jest/test-result": "30.0.5",
+        "@jest/core": "30.1.0",
+        "@jest/test-result": "30.1.0",
         "@jest/types": "30.0.5",
         "chalk": "^4.1.2",
         "exit-x": "^0.2.2",
         "import-local": "^3.2.0",
-        "jest-config": "30.0.5",
+        "jest-config": "30.1.0",
         "jest-util": "30.0.5",
-        "jest-validate": "30.0.5",
+        "jest-validate": "30.1.0",
         "yargs": "^17.7.2"
       },
       "bin": {
@@ -5891,31 +5891,31 @@
       }
     },
     "node_modules/jest-config": {
-      "version": "30.0.5",
-      "resolved": "https://registry.npmjs.org/jest-config/-/jest-config-30.0.5.tgz",
-      "integrity": "sha512-aIVh+JNOOpzUgzUnPn5FLtyVnqc3TQHVMupYtyeURSb//iLColiMIR8TxCIDKyx9ZgjKnXGucuW68hCxgbrwmA==",
+      "version": "30.1.0",
+      "resolved": "https://registry.npmjs.org/jest-config/-/jest-config-30.1.0.tgz",
+      "integrity": "sha512-XqpN5l/DkQQJIFig+eZL2KiBTXrhV9MUXQtstX0ES3XhgIujQppUagF79CI86ES3pp/UVVJVwQyCBt89I9nsJA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.27.4",
-        "@jest/get-type": "30.0.1",
+        "@jest/get-type": "30.1.0",
         "@jest/pattern": "30.0.1",
-        "@jest/test-sequencer": "30.0.5",
+        "@jest/test-sequencer": "30.1.0",
         "@jest/types": "30.0.5",
-        "babel-jest": "30.0.5",
+        "babel-jest": "30.1.0",
         "chalk": "^4.1.2",
         "ci-info": "^4.2.0",
         "deepmerge": "^4.3.1",
         "glob": "^10.3.10",
         "graceful-fs": "^4.2.11",
-        "jest-circus": "30.0.5",
+        "jest-circus": "30.1.0",
         "jest-docblock": "30.0.1",
-        "jest-environment-node": "30.0.5",
+        "jest-environment-node": "30.1.0",
         "jest-regex-util": "30.0.1",
-        "jest-resolve": "30.0.5",
-        "jest-runner": "30.0.5",
+        "jest-resolve": "30.1.0",
+        "jest-runner": "30.1.0",
         "jest-util": "30.0.5",
-        "jest-validate": "30.0.5",
+        "jest-validate": "30.1.0",
         "micromatch": "^4.0.8",
         "parse-json": "^5.2.0",
         "pretty-format": "30.0.5",
@@ -5943,14 +5943,14 @@
       }
     },
     "node_modules/jest-diff": {
-      "version": "30.0.5",
-      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-30.0.5.tgz",
-      "integrity": "sha512-1UIqE9PoEKaHcIKvq2vbibrCog4Y8G0zmOxgQUVEiTqwR5hJVMCoDsN1vFvI5JvwD37hjueZ1C4l2FyGnfpE0A==",
+      "version": "30.1.0",
+      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-30.1.0.tgz",
+      "integrity": "sha512-DHkvlHONjXknCIzYqFCIqH9uT0G6ZMN0U9Brb64BbQnCmVNcILa3FLTHh21h+E1oNRpaTvupTQTCiOhz2hx7hw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jest/diff-sequences": "30.0.1",
-        "@jest/get-type": "30.0.1",
+        "@jest/get-type": "30.1.0",
         "chalk": "^4.1.2",
         "pretty-format": "30.0.5"
       },
@@ -5972,13 +5972,13 @@
       }
     },
     "node_modules/jest-each": {
-      "version": "30.0.5",
-      "resolved": "https://registry.npmjs.org/jest-each/-/jest-each-30.0.5.tgz",
-      "integrity": "sha512-dKjRsx1uZ96TVyejD3/aAWcNKy6ajMaN531CwWIsrazIqIoXI9TnnpPlkrEYku/8rkS3dh2rbH+kMOyiEIv0xQ==",
+      "version": "30.1.0",
+      "resolved": "https://registry.npmjs.org/jest-each/-/jest-each-30.1.0.tgz",
+      "integrity": "sha512-A+9FKzxPluqogNahpCv04UJvcZ9B3HamqpDNWNKDjtxVRYB8xbZLFuCr8JAJFpNp83CA0anGQFlpQna9Me+/tQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@jest/get-type": "30.0.1",
+        "@jest/get-type": "30.1.0",
         "@jest/types": "30.0.5",
         "chalk": "^4.1.2",
         "jest-util": "30.0.5",
@@ -5989,28 +5989,28 @@
       }
     },
     "node_modules/jest-environment-node": {
-      "version": "30.0.5",
-      "resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-30.0.5.tgz",
-      "integrity": "sha512-ppYizXdLMSvciGsRsMEnv/5EFpvOdXBaXRBzFUDPWrsfmog4kYrOGWXarLllz6AXan6ZAA/kYokgDWuos1IKDA==",
+      "version": "30.1.0",
+      "resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-30.1.0.tgz",
+      "integrity": "sha512-PoHcBVniqBcJubrLbMSrDIzD3RONpnqPeuNB1dOvU4aWzuV5vwViAtZtvAPtcZJW6i4n2YAAM+r8AvKWgUegmA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@jest/environment": "30.0.5",
-        "@jest/fake-timers": "30.0.5",
+        "@jest/environment": "30.1.0",
+        "@jest/fake-timers": "30.1.0",
         "@jest/types": "30.0.5",
         "@types/node": "*",
         "jest-mock": "30.0.5",
         "jest-util": "30.0.5",
-        "jest-validate": "30.0.5"
+        "jest-validate": "30.1.0"
       },
       "engines": {
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
     "node_modules/jest-haste-map": {
-      "version": "30.0.5",
-      "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-30.0.5.tgz",
-      "integrity": "sha512-dkmlWNlsTSR0nH3nRfW5BKbqHefLZv0/6LCccG0xFCTWcJu8TuEwG+5Cm75iBfjVoockmO6J35o5gxtFSn5xeg==",
+      "version": "30.1.0",
+      "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-30.1.0.tgz",
+      "integrity": "sha512-JLeM84kNjpRkggcGpQLsV7B8W4LNUWz7oDNVnY1Vjj22b5/fAb3kk3htiD+4Na8bmJmjJR7rBtS2Rmq/NEcADg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6021,7 +6021,7 @@
         "graceful-fs": "^4.2.11",
         "jest-regex-util": "30.0.1",
         "jest-util": "30.0.5",
-        "jest-worker": "30.0.5",
+        "jest-worker": "30.1.0",
         "micromatch": "^4.0.8",
         "walker": "^1.0.8"
       },
@@ -6033,13 +6033,13 @@
       }
     },
     "node_modules/jest-leak-detector": {
-      "version": "30.0.5",
-      "resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-30.0.5.tgz",
-      "integrity": "sha512-3Uxr5uP8jmHMcsOtYMRB/zf1gXN3yUIc+iPorhNETG54gErFIiUhLvyY/OggYpSMOEYqsmRxmuU4ZOoX5jpRFg==",
+      "version": "30.1.0",
+      "resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-30.1.0.tgz",
+      "integrity": "sha512-AoFvJzwxK+4KohH60vRuHaqXfWmeBATFZpzpmzNmYTtmRMiyGPVhkXpBqxUQunw+dQB48bDf4NpUs6ivVbRv1g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@jest/get-type": "30.0.1",
+        "@jest/get-type": "30.1.0",
         "pretty-format": "30.0.5"
       },
       "engines": {
@@ -6047,15 +6047,15 @@
       }
     },
     "node_modules/jest-matcher-utils": {
-      "version": "30.0.5",
-      "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-30.0.5.tgz",
-      "integrity": "sha512-uQgGWt7GOrRLP1P7IwNWwK1WAQbq+m//ZY0yXygyfWp0rJlksMSLQAA4wYQC3b6wl3zfnchyTx+k3HZ5aPtCbQ==",
+      "version": "30.1.0",
+      "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-30.1.0.tgz",
+      "integrity": "sha512-A0/O5+WzSmeBrsm1PMOLyKkKUekbCbAtgyViRvJagjMnOsuKQbukiHJy7y+7cTST9pvoi81NyHXz5Fc96UoKUQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@jest/get-type": "30.0.1",
+        "@jest/get-type": "30.1.0",
         "chalk": "^4.1.2",
-        "jest-diff": "30.0.5",
+        "jest-diff": "30.1.0",
         "pretty-format": "30.0.5"
       },
       "engines": {
@@ -6063,9 +6063,9 @@
       }
     },
     "node_modules/jest-message-util": {
-      "version": "30.0.5",
-      "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-30.0.5.tgz",
-      "integrity": "sha512-NAiDOhsK3V7RU0Aa/HnrQo+E4JlbarbmI3q6Pi4KcxicdtjV82gcIUrejOtczChtVQR4kddu1E1EJlW6EN9IyA==",
+      "version": "30.1.0",
+      "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-30.1.0.tgz",
+      "integrity": "sha512-HizKDGG98cYkWmaLUHChq4iN+oCENohQLb7Z5guBPumYs+/etonmNFlg1Ps6yN9LTPyZn+M+b/9BbnHx3WTMDg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6127,18 +6127,18 @@
       }
     },
     "node_modules/jest-resolve": {
-      "version": "30.0.5",
-      "resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-30.0.5.tgz",
-      "integrity": "sha512-d+DjBQ1tIhdz91B79mywH5yYu76bZuE96sSbxj8MkjWVx5WNdt1deEFRONVL4UkKLSrAbMkdhb24XN691yDRHg==",
+      "version": "30.1.0",
+      "resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-30.1.0.tgz",
+      "integrity": "sha512-hASe7D/wRtZw8Cm607NrlF7fi3HWC5wmA5jCVc2QjQAB2pTwP9eVZILGEi6OeSLNUtE1zb04sXRowsdh5CUjwA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "chalk": "^4.1.2",
         "graceful-fs": "^4.2.11",
-        "jest-haste-map": "30.0.5",
+        "jest-haste-map": "30.1.0",
         "jest-pnp-resolver": "^1.2.3",
         "jest-util": "30.0.5",
-        "jest-validate": "30.0.5",
+        "jest-validate": "30.1.0",
         "slash": "^3.0.0",
         "unrs-resolver": "^1.7.11"
       },
@@ -6147,30 +6147,30 @@
       }
     },
     "node_modules/jest-resolve-dependencies": {
-      "version": "30.0.5",
-      "resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-30.0.5.tgz",
-      "integrity": "sha512-/xMvBR4MpwkrHW4ikZIWRttBBRZgWK4d6xt3xW1iRDSKt4tXzYkMkyPfBnSCgv96cpkrctfXs6gexeqMYqdEpw==",
+      "version": "30.1.0",
+      "resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-30.1.0.tgz",
+      "integrity": "sha512-pNWAfnzoqPWPYNaHwWmR34+5ib9DcUr5E+GLyIxjGxZEwdfgYnXLjPP3WfSW0VaTUnYes1Tl0cQNyBPr5plZmg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "jest-regex-util": "30.0.1",
-        "jest-snapshot": "30.0.5"
+        "jest-snapshot": "30.1.0"
       },
       "engines": {
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
     "node_modules/jest-runner": {
-      "version": "30.0.5",
-      "resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-30.0.5.tgz",
-      "integrity": "sha512-JcCOucZmgp+YuGgLAXHNy7ualBx4wYSgJVWrYMRBnb79j9PD0Jxh0EHvR5Cx/r0Ce+ZBC4hCdz2AzFFLl9hCiw==",
+      "version": "30.1.0",
+      "resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-30.1.0.tgz",
+      "integrity": "sha512-Qd8JLWBooJQZBbstY9sdzt3B3Euj4cjDB0X+CeExURm1+BqZcXA5pSPb4XwbgPlBhTXkUva3bb0B94CFy9ZnZw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@jest/console": "30.0.5",
-        "@jest/environment": "30.0.5",
-        "@jest/test-result": "30.0.5",
-        "@jest/transform": "30.0.5",
+        "@jest/console": "30.1.0",
+        "@jest/environment": "30.1.0",
+        "@jest/test-result": "30.1.0",
+        "@jest/transform": "30.1.0",
         "@jest/types": "30.0.5",
         "@types/node": "*",
         "chalk": "^4.1.2",
@@ -6178,15 +6178,15 @@
         "exit-x": "^0.2.2",
         "graceful-fs": "^4.2.11",
         "jest-docblock": "30.0.1",
-        "jest-environment-node": "30.0.5",
-        "jest-haste-map": "30.0.5",
-        "jest-leak-detector": "30.0.5",
-        "jest-message-util": "30.0.5",
-        "jest-resolve": "30.0.5",
-        "jest-runtime": "30.0.5",
+        "jest-environment-node": "30.1.0",
+        "jest-haste-map": "30.1.0",
+        "jest-leak-detector": "30.1.0",
+        "jest-message-util": "30.1.0",
+        "jest-resolve": "30.1.0",
+        "jest-runtime": "30.1.0",
         "jest-util": "30.0.5",
-        "jest-watcher": "30.0.5",
-        "jest-worker": "30.0.5",
+        "jest-watcher": "30.1.0",
+        "jest-worker": "30.1.0",
         "p-limit": "^3.1.0",
         "source-map-support": "0.5.13"
       },
@@ -6195,18 +6195,18 @@
       }
     },
     "node_modules/jest-runtime": {
-      "version": "30.0.5",
-      "resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-30.0.5.tgz",
-      "integrity": "sha512-7oySNDkqpe4xpX5PPiJTe5vEa+Ak/NnNz2bGYZrA1ftG3RL3EFlHaUkA1Cjx+R8IhK0Vg43RML5mJedGTPNz3A==",
+      "version": "30.1.0",
+      "resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-30.1.0.tgz",
+      "integrity": "sha512-tPKb7oCj1D0CffhJrP+yheK/lHx2PrMaK21BmBD3YUirr4E4gxXa6jNb9r9yhiD0LRv9J5AoTmzJVYeyWPgt6A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@jest/environment": "30.0.5",
-        "@jest/fake-timers": "30.0.5",
-        "@jest/globals": "30.0.5",
+        "@jest/environment": "30.1.0",
+        "@jest/fake-timers": "30.1.0",
+        "@jest/globals": "30.1.0",
         "@jest/source-map": "30.0.1",
-        "@jest/test-result": "30.0.5",
-        "@jest/transform": "30.0.5",
+        "@jest/test-result": "30.1.0",
+        "@jest/transform": "30.1.0",
         "@jest/types": "30.0.5",
         "@types/node": "*",
         "chalk": "^4.1.2",
@@ -6214,12 +6214,12 @@
         "collect-v8-coverage": "^1.0.2",
         "glob": "^10.3.10",
         "graceful-fs": "^4.2.11",
-        "jest-haste-map": "30.0.5",
-        "jest-message-util": "30.0.5",
+        "jest-haste-map": "30.1.0",
+        "jest-message-util": "30.1.0",
         "jest-mock": "30.0.5",
         "jest-regex-util": "30.0.1",
-        "jest-resolve": "30.0.5",
-        "jest-snapshot": "30.0.5",
+        "jest-resolve": "30.1.0",
+        "jest-snapshot": "30.1.0",
         "jest-util": "30.0.5",
         "slash": "^3.0.0",
         "strip-bom": "^4.0.0"
@@ -6229,9 +6229,9 @@
       }
     },
     "node_modules/jest-snapshot": {
-      "version": "30.0.5",
-      "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-30.0.5.tgz",
-      "integrity": "sha512-T00dWU/Ek3LqTp4+DcW6PraVxjk28WY5Ua/s+3zUKSERZSNyxTqhDXCWKG5p2HAJ+crVQ3WJ2P9YVHpj1tkW+g==",
+      "version": "30.1.0",
+      "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-30.1.0.tgz",
+      "integrity": "sha512-rBR/lTOi4ANpoqMhehPcGX/KGVXBEwe4V6HH27B3J1VZoXHXLk4nbMVGusbPc2y+of9/sU5uH2E998IlO7sLlQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6240,18 +6240,18 @@
         "@babel/plugin-syntax-jsx": "^7.27.1",
         "@babel/plugin-syntax-typescript": "^7.27.1",
         "@babel/types": "^7.27.3",
-        "@jest/expect-utils": "30.0.5",
-        "@jest/get-type": "30.0.1",
-        "@jest/snapshot-utils": "30.0.5",
-        "@jest/transform": "30.0.5",
+        "@jest/expect-utils": "30.1.0",
+        "@jest/get-type": "30.1.0",
+        "@jest/snapshot-utils": "30.1.0",
+        "@jest/transform": "30.1.0",
         "@jest/types": "30.0.5",
         "babel-preset-current-node-syntax": "^1.1.0",
         "chalk": "^4.1.2",
-        "expect": "30.0.5",
+        "expect": "30.1.0",
         "graceful-fs": "^4.2.11",
-        "jest-diff": "30.0.5",
-        "jest-matcher-utils": "30.0.5",
-        "jest-message-util": "30.0.5",
+        "jest-diff": "30.1.0",
+        "jest-matcher-utils": "30.1.0",
+        "jest-message-util": "30.1.0",
         "jest-util": "30.0.5",
         "pretty-format": "30.0.5",
         "semver": "^7.7.2",
@@ -6280,13 +6280,13 @@
       }
     },
     "node_modules/jest-validate": {
-      "version": "30.0.5",
-      "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-30.0.5.tgz",
-      "integrity": "sha512-ouTm6VFHaS2boyl+k4u+Qip4TSH7Uld5tyD8psQ8abGgt2uYYB8VwVfAHWHjHc0NWmGGbwO5h0sCPOGHHevefw==",
+      "version": "30.1.0",
+      "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-30.1.0.tgz",
+      "integrity": "sha512-7P3ZlCFW/vhfQ8pE7zW6Oi4EzvuB4sgR72Q1INfW9m0FGo0GADYlPwIkf4CyPq7wq85g+kPMtPOHNAdWHeBOaA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@jest/get-type": "30.0.1",
+        "@jest/get-type": "30.1.0",
         "@jest/types": "30.0.5",
         "camelcase": "^6.3.0",
         "chalk": "^4.1.2",
@@ -6311,13 +6311,13 @@
       }
     },
     "node_modules/jest-watcher": {
-      "version": "30.0.5",
-      "resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-30.0.5.tgz",
-      "integrity": "sha512-z9slj/0vOwBDBjN3L4z4ZYaA+pG56d6p3kTUhFRYGvXbXMWhXmb/FIxREZCD06DYUwDKKnj2T80+Pb71CQ0KEg==",
+      "version": "30.1.0",
+      "resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-30.1.0.tgz",
+      "integrity": "sha512-aXSHgnDY2XhHt7zo8MkdN0ovl/DbmPEw2KTEZRtH+4MeLZ+eYwnO+RIUk4nVlIx1wwH+7FZk+wPOYSDWDW3F4w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@jest/test-result": "30.0.5",
+        "@jest/test-result": "30.1.0",
         "@jest/types": "30.0.5",
         "@types/node": "*",
         "ansi-escapes": "^4.3.2",
@@ -6331,9 +6331,9 @@
       }
     },
     "node_modules/jest-worker": {
-      "version": "30.0.5",
-      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-30.0.5.tgz",
-      "integrity": "sha512-ojRXsWzEP16NdUuBw/4H/zkZdHOa7MMYCk4E430l+8fELeLg/mqmMlRhjL7UNZvQrDmnovWZV4DxX03fZF48fQ==",
+      "version": "30.1.0",
+      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-30.1.0.tgz",
+      "integrity": "sha512-uvWcSjlwAAgIu133Tt77A05H7RIk3Ho8tZL50bQM2AkvLdluw9NG48lRCl3Dt+MOH719n/0nnb5YxUwcuJiKRA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6879,9 +6879,9 @@
       "license": "MIT"
     },
     "node_modules/napi-postinstall": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/napi-postinstall/-/napi-postinstall-0.3.2.tgz",
-      "integrity": "sha512-tWVJxJHmBWLy69PvO96TZMZDrzmw5KeiZBz3RHmiM2XZ9grBJ2WgMAFVVg25nqp3ZjTFUs2Ftw1JhscL3Teliw==",
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/napi-postinstall/-/napi-postinstall-0.3.3.tgz",
+      "integrity": "sha512-uTp172LLXSxuSYHv/kou+f6KW3SMppU9ivthaVTXian9sOt3XM/zHYHpRZiLgQoxeWfYUnslNWQHF1+G71xcow==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -9093,9 +9093,9 @@
       }
     },
     "node_modules/typedoc": {
-      "version": "0.28.9",
-      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.28.9.tgz",
-      "integrity": "sha512-aw45vwtwOl3QkUAmWCnLV9QW1xY+FSX2zzlit4MAfE99wX+Jij4ycnpbAWgBXsRrxmfs9LaYktg/eX5Bpthd3g==",
+      "version": "0.28.11",
+      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.28.11.tgz",
+      "integrity": "sha512-1FqgrrUYGNuE3kImAiEDgAVVVacxdO4ZVTKbiOVDGkoeSB4sNwQaDpa8mta+Lw5TEzBFmGXzsg0I1NLRIoaSFw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -9117,9 +9117,9 @@
       }
     },
     "node_modules/typedoc-plugin-missing-exports": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/typedoc-plugin-missing-exports/-/typedoc-plugin-missing-exports-4.0.0.tgz",
-      "integrity": "sha512-Z4ei+853xppDEhcqzyeyRs4+R0kUuKQWnMK1EtSTEd5LFkgkdW5Bdn8vfo/rsCGbYVJxOWU99fxgM1mROw5Fug==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/typedoc-plugin-missing-exports/-/typedoc-plugin-missing-exports-4.1.0.tgz",
+      "integrity": "sha512-p1M5jXnEbQ4qqy0erJz41BBZEDb8XDrbLjndlH4RhYEcymbdQr0xLF6yUw1GWBrhSIfkU98m3BELMAiQh+R1zA==",
       "dev": true,
       "license": "MIT",
       "peerDependencies": {
@@ -9141,16 +9141,16 @@
       }
     },
     "node_modules/typescript-eslint": {
-      "version": "8.39.0",
-      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.39.0.tgz",
-      "integrity": "sha512-lH8FvtdtzcHJCkMOKnN73LIn6SLTpoojgJqDAxPm1jCR14eWSGPX8ul/gggBdPMk/d5+u9V854vTYQ8T5jF/1Q==",
+      "version": "8.41.0",
+      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.41.0.tgz",
+      "integrity": "sha512-n66rzs5OBXW3SFSnZHr2T685q1i4ODm2nulFJhMZBotaTavsS8TrI3d7bDlRSs9yWo7HmyWrN9qDu14Qv7Y0Dw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/eslint-plugin": "8.39.0",
-        "@typescript-eslint/parser": "8.39.0",
-        "@typescript-eslint/typescript-estree": "8.39.0",
-        "@typescript-eslint/utils": "8.39.0"
+        "@typescript-eslint/eslint-plugin": "8.41.0",
+        "@typescript-eslint/parser": "8.41.0",
+        "@typescript-eslint/typescript-estree": "8.41.0",
+        "@typescript-eslint/utils": "8.41.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -9684,9 +9684,9 @@
       "license": "ISC"
     },
     "node_modules/yaml": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.0.tgz",
-      "integrity": "sha512-4lLa/EcQCB0cJkyts+FpIRx5G/llPxfP6VQU5KByHEhLxY3IJCH0f0Hy1MHI8sClTvsIb8qwRJ6R/ZdlDJ/leQ==",
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.1.tgz",
+      "integrity": "sha512-lcYcMxX2PO9XMGvAJkJ3OsNMw+/7FKes7/hgerGUYWIoWu5j/+YQqcZr5JnPZWzOsEBgMbSbiSTn/dv/69Mkpw==",
       "dev": true,
       "license": "ISC",
       "bin": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -38,7 +38,7 @@
     "typecheck": "tsc"
   },
   "dependencies": {
-    "@supabase/postgrest-js": "^1.21.1",
+    "@supabase/postgrest-js": "^1.21.3",
     "dotenv": "^17.2.1",
     "express": "^4.21.2",
     "helmet": "^8.0.0",
@@ -56,8 +56,8 @@
     "@types/lodash.merge": "^4.6.9",
     "@types/mime-types": "^3.0.1",
     "@types/node": "^24.2.0",
-    "@typescript-eslint/eslint-plugin": "^8.34.0",
-    "@typescript-eslint/parser": "^8.38.0",
+    "@typescript-eslint/eslint-plugin": "^8.41.0",
+    "@typescript-eslint/parser": "^8.41.0",
     "eslint": "^9.34.0",
     "eslint-plugin-import": "^2.31.0",
     "jest": "^30.0.5",
@@ -68,7 +68,7 @@
     "typedoc": "^0.28.9",
     "typedoc-plugin-missing-exports": "^4.0.0",
     "typescript": "^5.9.2",
-    "typescript-eslint": "^8.39.0"
+    "typescript-eslint": "^8.41.0"
   },
   "engines": {
     "node": ">=20",

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -1,16 +1,21 @@
 import path from 'path';
 
+import { PostgrestClient } from '@supabase/postgrest-js';
 import dotenv from 'dotenv';
 import express from 'express';
 import helmet from 'helmet';
 
 import createApiRouter from './api/index';
-import { harmonizePublicKey } from './keycloak/keycloak';
+import { getPostgrestJwt, harmonizePublicKey } from './keycloak/keycloak';
 import { setupLogger } from './logger';
 import { Opts } from './types/opts';
 
 export const runapp = async () => {
   const opts = await prepare();
+  const isReady = await checkConnection(opts);
+  if (!isReady) {
+    process.exit(1);
+  }
   run(opts);
 };
 
@@ -50,6 +55,46 @@ const prepare = async () => {
   }
 
   return opts;
+};
+
+const checkConnection = async (opts: Opts): Promise<boolean> => {
+  const logger = setupLogger({ label: 'app:checkConnection' });
+  const postgrestToken = await getPostgrestJwt(opts);
+  if (!postgrestToken) {
+    logger.error('Failed to get postgrest token for postgrest client');
+    return false;
+  }
+
+  const pgClient = new PostgrestClient(opts.POSTGREST_URL, {
+    schema: opts.POSTGREST_DEFAULT_SCHEMA,
+    headers: {
+      Authorization: `Bearer ${postgrestToken}`
+    }
+  });
+
+  const response = await pgClient
+    .schema(opts.POSTGREST_DEFAULT_SCHEMA)
+    .from('__form_backend_healthcheck')
+    .update({
+      // eslint-disable-next-line camelcase
+      last_start: new Date().toISOString()
+    })
+    .eq('id', 1);
+  if (response.status && response.status >= 200 && response.status < 300) {
+    logger.info('App is ready - Connected via postgrest correctly.');
+    return true;
+  }
+
+  logger.error('App is not ready - Could not connect via postgrest correctly. Exiting.');
+  logger.error(`Status: ${response.status}`);
+  logger.error(`StatusText: ${response.statusText}`);
+  logger.error(`Error: ${JSON.stringify(response.error)}`);
+  if (response.error?.code === '42501') {
+    logger.error('Insufficient privileges for role "formbackend" - ' +
+      'Make sure the database migrations have been run correctly and postgrest is setup up correctly.'
+    );
+  }
+  return false;
 };
 
 const run = (opts: Opts) => {

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -31,6 +31,7 @@ const prepare = async () => {
     KC_CLIENT_APP_ID: process.env.KC_CLIENT_APP_ID,
     KC_PUBLIC_KEY: harmonizePublicKey(process.env.KC_PUBLIC_KEY),
     KC_REALM: process.env.KC_REALM,
+    LOG_LEVEL: process.env.LOG_LEVEL ?? 'info',
     POSTGREST_DEFAULT_SCHEMA: process.env.POSTGREST_DEFAULT_SCHEMA ?? 'public',
     POSTGREST_JWT_CLIENT_ID: process.env.POSTGREST_JWT_CLIENT_ID,
     POSTGREST_KEYCLOAK_CLIENT_SECRET: process.env.POSTGREST_KEYCLOAK_CLIENT_SECRET,

--- a/backend/src/keycloak/keycloak.ts
+++ b/backend/src/keycloak/keycloak.ts
@@ -86,5 +86,12 @@ export const getPostgrestJwt = async (opts: Opts) => {
     return;
   }
   const data = await response.json();
+
+  if (opts.LOG_LEVEL === 'verbose') {
+    logger.verbose('Got postgrest jwt');
+    const jwtPayload = decodeToken(data.access_token, opts);
+    logger.verbose(`Granted resources: ${JSON.stringify(jwtPayload?.resource_access ?? {})}`);
+  }
+
   return data.access_token;
 };

--- a/backend/src/processor/data.ts
+++ b/backend/src/processor/data.ts
@@ -188,7 +188,10 @@ class DataProcessor {
     formConfig: FormConfigInternal | JoinTable,
     configKey?: string
   ) {
-    this.#logger.debug(`Updating item ${itemId} for configKey ${configKey}`);
+    this.#logger.debug(`Updating item ${itemId}`);
+    if (configKey) {
+      this.#logger.debug(`for configKey ${configKey}`);
+    }
     let sanitizedData = this.#sanitizeData(item, formConfig);
     const keysAndFiles = this.#fileProcessor.getFilesFromItem(sanitizedData, formConfig);
     sanitizedData = await this.#fileProcessor.createFiles({
@@ -275,7 +278,10 @@ class DataProcessor {
           configKeys?.join('/')
         );
         itemId = updatedItem.id;
-        this.#logger.debug(`Updated item ${itemId} for configKeys ${configKeys}`);
+        this.#logger.debug(`Updated item ${itemId}`);
+        if (configKeys) {
+          this.#logger.debug(`for configKeys ${configKeys}`);
+        }
         break;
       }
       case DbAction.DELETE:

--- a/backend/src/processor/formConfig.ts
+++ b/backend/src/processor/formConfig.ts
@@ -2,6 +2,7 @@ import { PostgrestClient } from '@supabase/postgrest-js';
 import merge from 'lodash.merge';
 import { Logger } from 'winston';
 
+import { FormBackendErrorCode } from '../errors/FormBackendErrorCode';
 import { DatabaseError } from '../errors/GenericRequestError';
 import { setupLogger } from '../logger';
 import { isFormConfig } from '../typeguards/formConfig';
@@ -11,7 +12,6 @@ import { FormConfigPublic } from '../types/formConfigPublic';
 import { JoinTable } from '../types/joinTable';
 import { Opts } from '../types/opts';
 import { Relationship } from '../types/relationship';
-import { FormBackendErrorCode } from '../errors/FormBackendErrorCode';
 
 class FormConfigProcessor {
 


### PR DESCRIPTION
## Description

<!-- Please give a short description of the changes you propose. Please use prose and try not to be too technical, if possible. Make sure to mention people that you think should know about the PR. -->

* Added `checkConnection` function to validate PostgREST connectivity before starting the app.
* Uses a healthcheck table (`__form_backend_healthcheck`) to update last_start timestamp and confirm readiness. 
* Logs detailed error information if connection fails, including insufficient privileges hint.
* Default `LOG_LEVEL` now falls back to info when not set via environment.

## Related issues or pull requests

<!-- Please list issues or pull requests that the changes you propose are related to. It does not matter if they are still open and/or unmerged, any link is appreciated. -->
* See also https://github.com/formcapture/form-backend-demo/pull/26

## Pull request type

<!-- Please check the type of change your PR introduces: -->

<!-- Put an x between the square brackets to check an item, like so: [x] -->

- [ ] Bugfix
- [x] Feature
- [ ] Dependency updates
- [ ] Tests
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe)

## Do you introduce a breaking change?

- [ ] Yes
- [x] No

## Checklist

- [x] I understand and agree that the changes in this PR will be licensed under the 
  [BSD 2-Clause Licence](https://github.com/formcapture/form-backend/blob/main/LICENSE).
- [x] I have followed the [guidelines for contributing](https://github.com/formcapture/form-backend/blob/main/CONTRIBUTING.md).
- [x] The proposed change fits to the content of the [code of conduct](https://github.com/formcapture/form-backend/blob/main/CODE_OF_CONDUCT.md).
- [ ] I have added or updated tests and documentation, and the test suite passes (run `npm test` in `/backend` and/or `/app` locally).
- [ ] I have added a screenshot/screencast to illustrate the visual output of my update.
