### PR TITLE
fix: improve error page login

### DIFF
--- a/app/src/App.spec.tsx
+++ b/app/src/App.spec.tsx
@@ -238,8 +238,19 @@ describe('App', () => {
     render(<App />);
 
     await waitFor(() => {
-      expect(screen.queryByText('Seite wird geladen…')).toBeNull();
+      // Keycloak redirect is in progress — the loading page must stay visible
+      // so the user never sees a blank screen or an error page.
+      expect(screen.getByText('Seite wird geladen…')).not.toBeNull();
     }, {timeout: 400});
+
+    // No error page should be rendered — the 401 is not a permission error,
+    // it just means the user is not logged in yet.
+    expect(screen.queryByRole('alert')).toBeNull();
+
+    // Keycloak should have been initialised with login-required to trigger the redirect.
+    expect(mockKeycloak.init).toHaveBeenCalledWith(
+      expect.objectContaining({ onLoad: 'login-required' })
+    );
   });
 
   it('shows error if unauthorized with token', async () => {

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -134,6 +134,7 @@ const App: React.FC = () => {
   const [data, setData] = useState(null);
   const [isLoading, setIsLoading] = useState(true);
   const [unauthorizedWithToken, setUnauthorizedWithToken] = useState(false);
+  const [isRedirectingToLogin, setIsRedirectingToLogin] = useState(false);
   const [toastVisible, setToastVisible] = useState(!!message);
   const [toastMessageType, setToastMessageType] = useState<TOAST_MESSAGE>(message as TOAST_MESSAGE);
   const [statusCode, setStatusCode] = useState<number>(200);
@@ -142,9 +143,12 @@ const App: React.FC = () => {
 
   const handleUnauthorized = async (keycloakConfig: KeycloakConfig, kc?: Keycloak) => {
     if (kc?.token) {
+      // User is authenticated but lacks permission (403-equivalent) → show error page
       setUnauthorizedWithToken(true);
       return;
     }
+    // User is not logged in at all → redirect silently without showing an error page
+    setIsRedirectingToLogin(true);
     await redirectToLogin(keycloakConfig);
   };
 
@@ -181,15 +185,19 @@ const App: React.FC = () => {
         response = await api.getEmptyForm(formId, kc);
       }
       const status = response.status;
-      setStatusCode(status);
       const json = await response.json();
+      if (status === 401) {
+        // Not authenticated — do not set statusCode here; caller will trigger
+        // a Keycloak redirect and we do not want to flash an error page.
+        return { error: status };
+      }
       if (status >= 400) {
+        // Authenticated but forbidden (403) or another server error
+        setStatusCode(status);
         setAdditionalMessage(json.message);
         setErrorInfo(json.extra);
         Logger.error('An error occurred while fetching data, passing error to ErrorPage', new Error(json.message));
-        return {
-          error: status
-        };
+        return { error: status };
       }
       if (json.config === undefined) {
         throw new Error('Failed to fetch data');
@@ -269,6 +277,11 @@ const App: React.FC = () => {
   const isValidUrl = (view === 'table' && formId && !itemId) || (view === 'item' && formId);
 
   const shouldShowError = useMemo(() => {
+    // Never show an error page while Keycloak is redirecting to login —
+    // the user simply isn't authenticated yet.
+    if (isRedirectingToLogin) {
+      return false;
+    }
     if (statusCode !== 200) {
       return true;
     }
@@ -276,7 +289,7 @@ const App: React.FC = () => {
       return true;
     }
     return unauthorizedWithToken;
-  }, [isLoading, isValidUrl, statusCode, unauthorizedWithToken]);
+  }, [isLoading, isRedirectingToLogin, isValidUrl, statusCode, unauthorizedWithToken]);
 
   const showTableView = data && formId && view === 'table';
   const showItemView = view === 'item' && data && formId;
@@ -285,7 +298,7 @@ const App: React.FC = () => {
     return <ErrorPage statusCode={statusCode} errorInfo={errorInfo} />;
   }
 
-  if (isLoading) {
+  if (isLoading || isRedirectingToLogin) {
     return <LoadingPage />;
   }
 


### PR DESCRIPTION
## Description

<!-- Please give a short description of the changes you propose. Please use prose and try not to be too technical, if possible. Make sure to mention people that you think should know about the PR. -->
### Case
Permission needed to read form. Not logged in. No keycloak token.
### Old and unwanted behaviour
Unauthenticated user opens form, error page is rendered, then redirect to keycloak login.
### Fix
No error page, just loading page is shown, then redirect to keycloak login.

[
<img width="1053" height="754" alt="Peek 2026-05-05 11-21" src="https://github.com/user-attachments/assets/f1aea6f6-4a01-4a43-8ff8-13710168d4c0" />
](url)

Code fix partly supported by ai.

## Related issues or pull requests

<!-- Please list issues or pull requests that the changes you propose are related to. It does not matter if they are still open and/or unmerged, any link is appreciated. -->

## Pull request type

<!-- Please check the type of change your PR introduces: -->

<!-- Put an x between the square brackets to check an item, like so: [x] -->

- [x] Bugfix
- [ ] Feature
- [ ] Dependency updates
- [x] Tests
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe)

## Do you introduce a breaking change?

- [ ] Yes
- [x] No

## Checklist

- [x] I understand and agree that the changes in this PR will be licensed under the 
  [BSD 2-Clause Licence](https://github.com/formcapture/form-backend/blob/main/LICENSE).
- [x] I have followed the [guidelines for contributing](https://github.com/formcapture/form-backend/blob/main/CONTRIBUTING.md).
- [x] The proposed change fits to the content of the [code of conduct](https://github.com/formcapture/form-backend/blob/main/CODE_OF_CONDUCT.md).
- [x] I have added or updated tests and documentation, and the test suite passes (run `npm test` in `/backend` and/or `/app` locally).
- [] I have added a screenshot/screencast to illustrate the visual output of my update.
