### PR TITLE
fix: render draw buttons only when editable

### DIFF
--- a/app/src/Component/GeometryEditor/GeometryEditor.tsx
+++ b/app/src/Component/GeometryEditor/GeometryEditor.tsx
@@ -115,7 +115,7 @@ export class GeometryEditor extends AbstractEditor {
 
     this.geometryType = this.getGeometryType(this.schema.format);
 
-    if (!this.schema.readOnly) {
+    if (!this.schema.readOnly && this.options?.parent?.schema?.editable) {
       this.formButtons = this.createButtons();
     }
 
@@ -184,8 +184,8 @@ export class GeometryEditor extends AbstractEditor {
   }
 
   onStartDrawClick() {
-    const endDrawButton = this.formButtons.querySelector(`#end-draw-${this.key}`);
-    const startDrawButton = this.formButtons.querySelector(`#start-draw-${this.key}`);
+    const endDrawButton = this.formButtons?.querySelector(`#end-draw-${this.key}`);
+    const startDrawButton = this.formButtons?.querySelector(`#start-draw-${this.key}`);
 
     if (endDrawButton) {
       endDrawButton.style.display = 'inline';
@@ -214,8 +214,8 @@ export class GeometryEditor extends AbstractEditor {
   }
 
   endDrawing() {
-    const endDrawButton = this.formButtons.querySelector(`#end-draw-${this.key}`);
-    const startDrawButton = this.formButtons.querySelector(`#start-draw-${this.key}`);
+    const endDrawButton = this.formButtons?.querySelector(`#end-draw-${this.key}`);
+    const startDrawButton = this.formButtons?.querySelector(`#start-draw-${this.key}`);
 
     if (endDrawButton) {
       endDrawButton.style.display = 'none';
@@ -239,7 +239,7 @@ export class GeometryEditor extends AbstractEditor {
 
   updateGeometryIndicator() {
     const geom = this.value;
-    const iconEl = this.geometryIndicator.querySelector('i');
+    const iconEl = this.geometryIndicator?.querySelector('i');
     if (geom) {
       iconEl.classList.add('fb-geom-indicator-valid');
     } else {
@@ -257,7 +257,7 @@ export class GeometryEditor extends AbstractEditor {
   }
 
   updateZoomToFeatureButton(show: boolean) {
-    const zoomToFeatureButton = this.formButtons.querySelector(`#zoom-to-feature-${this.key}`);
+    const zoomToFeatureButton = this.formButtons?.querySelector(`#zoom-to-feature-${this.key}`);
     if (zoomToFeatureButton) {
       zoomToFeatureButton.style.display = show ? 'inline' : 'none';
     }

--- a/app/src/Component/GeometrySelection/GeometrySelection.tsx
+++ b/app/src/Component/GeometrySelection/GeometrySelection.tsx
@@ -70,7 +70,7 @@ export class GeometrySelection extends AbstractEditor {
     this.input.readOnly = this.schema.readOnly;
     this.input.disabled = this.schema.readOnly;
 
-    if (!this.schema.readOnly) {
+    if (!this.schema.readOnly && this.options?.parent?.schema?.editable) {
       this.formButtons = this.createButtons();
     }
 
@@ -139,8 +139,8 @@ export class GeometrySelection extends AbstractEditor {
   }
 
   onStartSelectClick() {
-    const endSelectButton = this.formButtons.querySelector(`#end-select-${this.key}`);
-    const startSelectButton = this.formButtons.querySelector(`#start-select-${this.key}`);
+    const endSelectButton = this.formButtons?.querySelector(`#end-select-${this.key}`);
+    const startSelectButton = this.formButtons?.querySelector(`#start-select-${this.key}`);
 
     if (endSelectButton) {
       endSelectButton.style.display = 'inline';
@@ -167,8 +167,8 @@ export class GeometrySelection extends AbstractEditor {
   }
 
   endSelecting() {
-    const endSelectButton = this.formButtons.querySelector(`#end-select-${this.key}`);
-    const startSelectButton = this.formButtons.querySelector(`#start-select-${this.key}`);
+    const endSelectButton = this.formButtons?.querySelector(`#end-select-${this.key}`);
+    const startSelectButton = this.formButtons?.querySelector(`#start-select-${this.key}`);
 
     if (endSelectButton) {
       endSelectButton.style.display = 'none';
@@ -191,7 +191,7 @@ export class GeometrySelection extends AbstractEditor {
 
   updateGeometryIndicator() {
     const geom = this.value;
-    const iconEl = this.geometryIndicator.querySelector('i');
+    const iconEl = this.geometryIndicator?.querySelector('i');
     if (geom) {
       iconEl.classList.add('fb-geom-indicator-valid');
     } else {
@@ -209,7 +209,7 @@ export class GeometrySelection extends AbstractEditor {
   }
 
   updateZoomToFeatureButton(show: boolean) {
-    const zoomToFeatureButton = this.formButtons.querySelector(`#zoom-to-feature-${this.key}`);
+    const zoomToFeatureButton = this.formButtons?.querySelector(`#zoom-to-feature-${this.key}`);
     if (zoomToFeatureButton) {
       zoomToFeatureButton.style.display = show ? 'inline' : 'none';
     }

--- a/app/src/Component/ItemView/ItemView.tsx
+++ b/app/src/Component/ItemView/ItemView.tsx
@@ -88,7 +88,7 @@ const ItemView: React.FC<ItemViewProps> = ({
       disable_array_add: !editable,
       disable_array_delete: !editable,
       form_name_root: formId,
-      schema: data.config,
+      schema: { ...data.config, editable},
       // TODO check embedded mode
       internalMap: internalMap
     });


### PR DESCRIPTION
## Description

<!-- Please give a short description of the changes you propose. Please use prose and try not to be too technical, if possible. Make sure to mention people that you think should know about the PR. -->
This should fix a bug: Draw Buttons are shown when form is not editable (case: user that is not authorized to write but can read the form).

- note: While `editable` refers to the form, `readOnly` refers to the input field

## Related issues or pull requests

<!-- Please list issues or pull requests that the changes you propose are related to. It does not matter if they are still open and/or unmerged, any link is appreciated. -->

## Pull request type

<!-- Please check the type of change your PR introduces: -->

<!-- Put an x between the square brackets to check an item, like so: [x] -->

- [x] Bugfix
- [ ] Feature
- [ ] Dependency updates
- [ ] Tests
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe)

## Do you introduce a breaking change?

- [ ] Yes
- [ ] No

## Checklist

- [x] I understand and agree that the changes in this PR will be licensed under the 
  [BSD 2-Clause Licence](https://github.com/formcapture/form-backend/blob/main/LICENSE).
- [x] I have followed the [guidelines for contributing](https://github.com/formcapture/form-backend/blob/main/CONTRIBUTING.md).
- [x] The proposed change fits to the content of the [code of conduct](https://github.com/formcapture/form-backend/blob/main/CODE_OF_CONDUCT.md).
- [ ] I have added or updated tests and documentation, and the test suite passes (run `npm test` in `/backend` and/or `/app` locally).
- [ ] I have added a screenshot/screencast to illustrate the visual output of my update.
